### PR TITLE
[UPDATE] fix payment name was not hidden when payment count is 1.

### DIFF
--- a/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
+++ b/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
@@ -38,7 +38,13 @@ public struct ReplyFormPaymentBlock: Component {
         }
     }
     
-    public init(payments: [Payment]) {
-        self.payments = payments
+    public init(payments: [Payment]) {        
+        self.payments = if payments.count == 1 {
+            payments.map{
+                $0.hideName()
+            }
+        }else{
+            payments
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 当仅有一项付款信息时，将自动隐藏付款人姓名，提升隐私保护。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->