### PR TITLE
[UPDATE] change quotation no prefix when organization is kd.

### DIFF
--- a/Sources/QuotationHTML/Organization.swift
+++ b/Sources/QuotationHTML/Organization.swift
@@ -33,6 +33,15 @@ public enum Organization: String, Codable, Sendable {
             self = .jw
         }
     }
+    
+    public var quotationNoPrefix: String{
+        switch self {
+        case .jw, .jwChanghua, .jwChiayi, .jwTaichung, .jwTaipei, .jwTaoyuan, .jwipo:
+            "嘉威稅字"
+        case .kd:
+            "康達稅字"
+        }
+    }
 
     public var headerResource: String {
         return "quotation-header-\(rawValue)"

--- a/Sources/QuotationHTML/Quotation.swift
+++ b/Sources/QuotationHTML/Quotation.swift
@@ -54,7 +54,7 @@ public struct AuditQuotation: Renderable {
             Page.break
             H3("專業服務公費報價單").style("text-align: center; font-size: 1.5rem;")
             if let no {
-                Paragraph("嘉威稅字第\(no)號").style("font-size: 0.6875rem; text-align: right;")
+                Paragraph("\(letterHeader.quotingOrganization.quotationNoPrefix)第\(no)號").style("font-size: 0.6875rem; text-align: right;")
             }
             
             if let contractHeader {

--- a/Sources/QuotationHTML/ReplyForm.swift
+++ b/Sources/QuotationHTML/ReplyForm.swift
@@ -56,7 +56,7 @@ public struct ReplyForm: Component{
                 TableRow{
                     TableCell("附　件：")
                     if let quotationNo {
-                        TableCell("嘉威稅字第\(quotationNo)號公費報價單")
+                        TableCell("\(sender.quotationNoPrefix)第\(quotationNo)號公費報價單")
                     }
                 }
             }.style("width: 100%;")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 报价编号前缀现在会根据不同组织动态显示，而不再是固定的“嘉威稅字”。
* **优化**
  * 报价单和回函表单中的报价编号前缀将根据实际组织自动调整，提升了灵活性和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->