### PR TITLE
[UPDATE] fix assistance title error.

### DIFF
--- a/Sources/QuotationHTML/Quotation.swift
+++ b/Sources/QuotationHTML/Quotation.swift
@@ -50,7 +50,7 @@ public struct AuditQuotation: Renderable {
         self.letterHeader = .init(to: letterHeader.to, from: letterHeader.from, content: letterHeader.content, date: letterHeader.date, blessings: letterHeader.blessings)
         self.assistance = assistance.map{
             .init(title: $0.title, items: $0.items.map{
-                .init(title: $0.content, content: $0.content)
+                .init(title: $0.title, content: $0.content)
             })
         }
         self.notes = notes.contents.map{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复问题**
  * 修正了审核报价项的标题和内容显示不一致的问题，现在标题和内容会正确对应显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->