### PR TITLE
[UPDATE] fix assistance title error.

### DIFF
--- a/Sources/QuotationHTML/Quotation.swift
+++ b/Sources/QuotationHTML/Quotation.swift
@@ -50,7 +50,7 @@ public struct AuditQuotation: Renderable {
         self.letterHeader = .init(to: letterHeader.to, from: letterHeader.from, content: letterHeader.content, date: letterHeader.date, blessings: letterHeader.blessings)
         self.assistance = assistance.map{
             .init(title: $0.title, items: $0.items.map{
-                .init(title: $0.content, content: $0.content)
+                .init(title: $0.title, content: $0.content)
             })
         }
         self.notes = notes.contents.map{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修正了辅助项标题显示错误的问题，现在辅助项的标题将正确显示为其原有标题内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->