### PR TITLE
[UPDATE] fix service scope term padding.

### DIFF
--- a/Sources/QuotationHTML/ServiceScope.swift
+++ b/Sources/QuotationHTML/ServiceScope.swift
@@ -27,7 +27,7 @@ public struct ServiceScope: Component {
                         Div(Text("（\(offset.representToChineseString(offset: 1))）\(item.title)")).style("display: flex; text-indent: 2em;")
                         Div{
                             if let term = item.term{
-                                Div(term).style("display: flex; text-indent: 3em;")
+                                Div(term).style("display: flex; padding-left: 3em; text-indent: 2em;")
                             }
                         }.style("display: flex; flex-direction: column; padding-left: 2em;")
                         if let serviceItemTerms = item.serviceItemTerms{

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -54,7 +54,7 @@ import Foundation
     let serviceScope = ServiceScope(index: 0, model: .init(title: title, heading: content, items: quotingServiceTerms))
     
     #expect(serviceScope.render() == """
-<div style="break-inside: avoid-page;"><tr style="font-size: 1.1em;"><td>一、Quotation Service Scope</td></tr><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column; padding-left: 2em;"><div style="display: flex; text-indent: 3em;">ItemContent</div></div></div>
+<div style="break-inside: avoid-page;"><tr style="font-size: 1.1em;"><td>一、Quotation Service Scope</td></tr><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column; padding-left: 2em;"><div style="display: flex; padding-left: 3em; text-indent: 2em;">ItemContent</div></div></div>
 """)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新增/变更样式
  - 调整服务条目中术语行的缩进与内边距（由单纯缩进改为结合左内边距与较小缩进），优化生成HTML/PDF的层级对齐与可读性，使列表项呈现更均衡的排版效果。

- 测试
  - 更新期望输出以匹配新的样式结构与缩进规则，确保生成内容在不同层级的缩进与对齐一致且稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->