### PR TITLE
[ADD] Payment supplementaryNote — per-payment 補充說明 row

### DIFF
--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -10,7 +10,11 @@ public struct Payment: Component {
     public let name: String
     public let items: [PaymentItem]
     public let needShowName: Bool
-    
+    /// 酬金補充說明（per-case 註解，例：「*財務簽證依預估資產總額新台幣壹億元報價」）。
+    /// 多行內容以 `\n` 分隔；render 時前綴單一個 `*`、整段 `white-space: pre-line` 保留換行。
+    /// `nil` 或空字串 → 不渲染此 row。
+    public let supplementaryNote: String?
+
     public var body: any Component{
         ComponentGroup{
             if needShowName {
@@ -26,17 +30,26 @@ public struct Payment: Component {
                     item
                 }.style("padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;")
             }
+            if let supplementaryNote, !supplementaryNote.isEmpty {
+                TableRow{
+                    TableCell()  // alignment 占位，對齊 (n) 編號欄
+                    TableCell{
+                        Text("*\(supplementaryNote)")
+                    }.attribute(named: "colspan", value: "2").style("white-space: pre-line; padding-top: 0.5em;")
+                }
+            }
         }
     }
-    
-    public init(name: String, items: [PaymentItem], needShowName: Bool = true) {
+
+    public init(name: String, items: [PaymentItem], needShowName: Bool = true, supplementaryNote: String? = nil) {
         self.name = name
         self.items = items
         self.needShowName = needShowName
+        self.supplementaryNote = supplementaryNote
     }
-    
+
     package func hideName() -> Self {
-        .init(name: name, items: items, needShowName: false)
+        .init(name: name, items: items, needShowName: false, supplementaryNote: supplementaryNote)
     }
 }
 
@@ -45,11 +58,13 @@ extension Payment {
         public let name: String
         public let items: [PaymentItem.Model]
         public let needShowName: Bool
-        
-        public init(name: String, items: [PaymentItem.Model], needShowName: Bool) {
+        public let supplementaryNote: String?
+
+        public init(name: String, items: [PaymentItem.Model], needShowName: Bool, supplementaryNote: String? = nil) {
             self.name = name
             self.items = items
             self.needShowName = needShowName
+            self.supplementaryNote = supplementaryNote
         }
     }
 }

--- a/Sources/QuotationHTML/extension/Array+Payment.swift
+++ b/Sources/QuotationHTML/extension/Array+Payment.swift
@@ -11,7 +11,8 @@ extension Array where Element == Payment {
             .init(
                 name: $0.name,
                 items: .init($0.items),
-                needShowName: $0.needShowName)
+                needShowName: $0.needShowName,
+                supplementaryNote: $0.supplementaryNote)
         }
     }
 }

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -81,11 +81,43 @@ import Foundation
         .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"], fee: "5,000 元/年"),
         .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: "6,000 元/年")
     ]
-    
+
     let payment = Payment(name: title, items: items)
     #expect(payment.render() == """
     <tr><td colspan="3"><b style="font-size: 1.1em;">酬金</b></td></tr><tr style="padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr><tr style="padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;"><td style="vertical-align: top; width: 1.35rem;">(2)</td><td><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">6,000 元/年</td></tr>
     """)
+}
+
+@Test func paymentRendersSupplementaryNoteRowWhenProvided(){
+    let payment = Payment(
+        name: "糕盛有限公司",
+        items: [
+            .init(names: ["民國 114 度財務報表查核簽證"], fee: "100,000 元/年")
+        ],
+        supplementaryNote: "財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"
+    )
+    // 多行 \n 在 HTML 中保留為 \n，由 `white-space: pre-line;` style 在渲染時轉成換行。
+    let rendered = payment.render()
+    #expect(rendered.contains("*財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"))
+    #expect(rendered.contains("white-space: pre-line"))
+    #expect(rendered.contains("colspan=\"2\""))
+}
+
+@Test func paymentOmitsSupplementaryNoteRowWhenNil(){
+    let payment = Payment(
+        name: "X",
+        items: [.init(names: ["item"], fee: "1 元/年")]
+    )
+    #expect(!payment.render().contains("white-space: pre-line"))
+}
+
+@Test func paymentOmitsSupplementaryNoteRowWhenEmptyString(){
+    let payment = Payment(
+        name: "X",
+        items: [.init(names: ["item"], fee: "1 元/年")],
+        supplementaryNote: ""
+    )
+    #expect(!payment.render().contains("white-space: pre-line"))
 }
 
 @Test("two payment", arguments: [


### PR DESCRIPTION
## Summary

- `Payment` / `Payment.Model` 新增 `supplementaryNote: String?` 欄位（backward compatible default `nil`）
- render 時表格底加一 row：col1 空格對齊 `(n)` 編號欄、col2+3 `colspan=2` 顯示 `*{supplementaryNote}`，`white-space: pre-line` 保留 `\n` 多行
- `Array<Payment>.init([Payment.Model])` 透傳新欄位
- 3 個 unit test：有值渲染（驗 `*` 前綴 / pre-line / colspan）、`nil` 不渲染、空字串不渲染

## 動機

OC 端 PDF 報價單每個 case 的酬金欄底下需要顯示「假設備註」（例：「*財務簽證依預估資產總額...報價」「*會計帳務處理作業依照預估年營收...報價」），先前無欄位可接、實際印出來只看到 paymentItems。本次補上後 OC 一側 `QuotationHTMLConverterComposer` 可透傳 case 的 supplementaryNote 給 PDF lib（OC PR 另開）。

## Test plan

- [x] `swift test` 全綠（原 14 + 新 3 = 17/17）
- [ ] OC 端 follow-up PR merge 後實際出 PDF 驗 layout（HTML 已驗過 layout 對；PDF 走 weasyprint 需本機 native lib，留到部署環境驗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支付表格现已支持添加可选的补充备注
  * 备注支持多行内容展示

* **测试**
  * 补充备注的渲染规则已通过单元测试覆盖

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mendesky/PDFGenerator/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->