### PR TITLE
Payment supplementaryNote 改用 raw HTML inject — 支援富文字格式

### DIFF
--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -11,8 +11,14 @@ public struct Payment: Component {
     public let items: [PaymentItem]
     public let needShowName: Bool
     /// 酬金補充說明（per-case 註解，例：「*財務簽證依預估資產總額新台幣壹億元報價」）。
-    /// 多行內容以 `\n` 分隔；render 時前綴單一個 `*`、整段 `white-space: pre-line` 保留換行。
-    /// `nil` 或空字串 → 不渲染此 row。
+    /// **HTML 字串**（非純文字）— render 時前綴單一個 `*`、整段以 raw HTML inject 到 `<td>`，
+    /// 不做 HTML escape。caller（OC composer）負責把 markdown + 內嵌 HTML 轉成乾淨 HTML 字串
+    /// （含內嵌圖片轉 data URI、template variable 替換等）後才傳入。
+    /// `white-space: pre-line` 保留換行；`nil` 或空字串 → 不渲染此 row。
+    ///
+    /// **語意變更（2026-06）**：原為純文字 `Text()` rendering、escape HTML chars；frontend 引入富文字
+    /// 編輯（粗體 / 底線 / 刪除線 / 圖片 / 表格等）後改為 HTML。既有純文字 caller 仍可正常渲染
+    /// （無 HTML tag 即等同純文字），但若內含 `<` `>` `&` 等 HTML 字元需 caller 先 escape。
     public let supplementaryNote: String?
 
     public var body: any Component{
@@ -33,9 +39,9 @@ public struct Payment: Component {
             if let supplementaryNote, !supplementaryNote.isEmpty {
                 TableRow{
                     TableCell()  // alignment 占位，對齊 (n) 編號欄
-                    TableCell{
-                        Text("*\(supplementaryNote)")
-                    }.attribute(named: "colspan", value: "2").style("white-space: pre-line; padding-top: 0.5em;")
+                    TableCell(html: "*\(supplementaryNote)")
+                        .attribute(named: "colspan", value: "2")
+                        .style("white-space: pre-line; padding-top: 0.5em;")
                 }
             }
         }

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -120,6 +120,33 @@ import Foundation
     #expect(!payment.render().contains("white-space: pre-line"))
 }
 
+/// 鎖 supplementaryNote 走 raw HTML inject — 內含 `<b>` / `<u>` 等 tag 不會被 escape。
+/// 對應 2026-06 富文字編輯支援（前端 markdown / HTML 混合內容轉 HTML 後傳入此欄位）。
+@Test func paymentRendersSupplementaryNoteAsRawHTML(){
+    let payment = Payment(
+        name: "X",
+        items: [.init(names: ["item"], fee: "1 元/年")],
+        supplementaryNote: "<b>粗體</b> <u>底線</u> <s>刪除線</s>"
+    )
+    let rendered = payment.render()
+    #expect(rendered.contains("*<b>粗體</b> <u>底線</u> <s>刪除線</s>"),
+        "HTML tag 應原樣 inject、不應被 escape 成 &lt;b&gt; 等")
+    #expect(!rendered.contains("&lt;b&gt;"), "確認沒 escape")
+}
+
+/// 鎖內嵌圖片（caller 已轉 data URI）正常 inject — `<img src="data:image/...">`。
+@Test func paymentRendersSupplementaryNoteWithEmbeddedImage(){
+    let dataUri = "data:image/png;base64,iVBORw0KGgo=" // 短的測試用 base64
+    let payment = Payment(
+        name: "X",
+        items: [.init(names: ["item"], fee: "1 元/年")],
+        supplementaryNote: "見附圖：<img src=\"\(dataUri)\" />"
+    )
+    let rendered = payment.render()
+    #expect(rendered.contains("<img src=\"\(dataUri)\""),
+        "data URI img tag 應原樣 inject、可被 weasyprint 渲染為實際圖片")
+}
+
 @Test("two payment", arguments: [
     ([
         Payment(name: "****作業(112 年度)", items: [


### PR DESCRIPTION
## Summary

Payment 模板的 supplementaryNote 從 plain text `Text()` 改為 raw HTML inject（Plot `TableCell(html:)` → `Node.raw`），支援前端富文字編輯器（粗體 / 底線 / 刪除線 / 標題 / 清單 / 表格 / 圖片 / span color 等）的輸出格式。

> 注意：本 commit (`2f0cf55`) 與 tag `1.22.0` 在 PR 開立前已 ad-hoc fast-forward push 到 main 並被 OC `dev/fixSupplementaryNoteSubstitution` 依賴。為補 review 紀錄、已將 main 暫時回退、改透過此 PR review + merge 回去。Tag 1.22.0 不動、OC 依賴解析不受影響。

## 變更

- `Payment.body` 內 supplementaryNote row：`TableCell { Text("*\(...)") }` → `TableCell(html: "*\(...)")`
- supplementaryNote 語意變更：純文字 → HTML 字串。caller 負責把 markdown + 內嵌 HTML 轉成乾淨 HTML（含 template variable 替換、內嵌圖片轉 data URI）後才傳入
- 既有純文字 caller 仍可正常渲染（無 HTML tag 即等同純文字）；含 `<` `>` `&` 字元者需 caller 先 escape

## Test plan

- [x] 既有 `paymentRendersSupplementaryNoteRowWhenProvided` 通過（純文字 caller backward compat）
- [x] 既有 `paymentOmitsSupplementaryNoteRowWhenNil` / `WhenEmptyString` 通過
- [x] 新增 `paymentRendersSupplementaryNoteAsRawHTML`：`<b>` / `<u>` / `<s>` 不被 escape
- [x] 新增 `paymentRendersSupplementaryNoteWithEmbeddedImage`：`<img src="data:...">` 原樣 inject

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 付款补充说明现支持 HTML 格式，允许使用文本样式（粗体、下划线、删除线）和内嵌图片显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->