### PR TITLE
拔掉 supplementaryNote 兩條純文字時代 legacy：white-space: pre-line + 硬寫的 `*` 前綴

### DIFF
--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -13,12 +13,17 @@ public struct Payment: Component {
     /// 酬金補充說明（per-case 註解，例：「*財務簽證依預估資產總額新台幣壹億元報價」）。
     /// **HTML 字串**（非純文字）— render 時前綴單一個 `*`、整段以 raw HTML inject 到 `<td>`，
     /// 不做 HTML escape。caller（OC composer）負責把 markdown + 內嵌 HTML 轉成乾淨 HTML 字串
-    /// （含內嵌圖片轉 data URI、template variable 替換等）後才傳入。
-    /// `white-space: pre-line` 保留換行；`nil` 或空字串 → 不渲染此 row。
+    /// （含內嵌圖片轉 data URI、template variable 替換等）+ 內嵌 scoped `<style>` block 控版面後傳入。
+    /// `nil` 或空字串 → 不渲染此 row。
     ///
     /// **語意變更（2026-06）**：原為純文字 `Text()` rendering、escape HTML chars；frontend 引入富文字
     /// 編輯（粗體 / 底線 / 刪除線 / 圖片 / 表格等）後改為 HTML。既有純文字 caller 仍可正常渲染
     /// （無 HTML tag 即等同純文字），但若內含 `<` `>` `&` 等 HTML 字元需 caller 先 escape。
+    ///
+    /// **無 `white-space: pre-line` style**（2026-06 拔掉）：原本為純文字 `\n` 換行設計的 legacy CSS；
+    /// HTML 時代由 HTML 結構自身（`<p>` / `<br>` / `<h*>` 等）控制換行，`pre-line` 會把 HTMLFormatter
+    /// 在 block tag 之間插入的實體 `\n` 顯示為**多餘可見換行**、造成大段空白。caller 若仍有純文字
+    /// `\n` 需求，應自行轉 `<br>`；本欄位不再做隱性 `\n` → 換行的 magic。
     public let supplementaryNote: String?
 
     public var body: any Component{
@@ -41,7 +46,7 @@ public struct Payment: Component {
                     TableCell()  // alignment 占位，對齊 (n) 編號欄
                     TableCell(html: "*\(supplementaryNote)")
                         .attribute(named: "colspan", value: "2")
-                        .style("white-space: pre-line; padding-top: 0.5em;")
+                        .style("padding-top: 0.5em;")
                 }
             }
         }

--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -10,20 +10,24 @@ public struct Payment: Component {
     public let name: String
     public let items: [PaymentItem]
     public let needShowName: Bool
-    /// 酬金補充說明（per-case 註解，例：「*財務簽證依預估資產總額新台幣壹億元報價」）。
-    /// **HTML 字串**（非純文字）— render 時前綴單一個 `*`、整段以 raw HTML inject 到 `<td>`，
-    /// 不做 HTML escape。caller（OC composer）負責把 markdown + 內嵌 HTML 轉成乾淨 HTML 字串
-    /// （含內嵌圖片轉 data URI、template variable 替換等）+ 內嵌 scoped `<style>` block 控版面後傳入。
+    /// 酬金補充說明（per-case 註解）。
+    /// **HTML 字串**（非純文字）— 整段以 raw HTML inject 到 `<td>`，不做 HTML escape、不加任何前綴。
+    /// caller（OC composer）負責把 markdown + 內嵌 HTML 轉成乾淨 HTML 字串（含內嵌圖片轉 data URI、
+    /// template variable 替換等）+ 內嵌 scoped `<style>` block 控版面後傳入。
     /// `nil` 或空字串 → 不渲染此 row。
     ///
-    /// **語意變更（2026-06）**：原為純文字 `Text()` rendering、escape HTML chars；frontend 引入富文字
-    /// 編輯（粗體 / 底線 / 刪除線 / 圖片 / 表格等）後改為 HTML。既有純文字 caller 仍可正常渲染
-    /// （無 HTML tag 即等同純文字），但若內含 `<` `>` `&` 等 HTML 字元需 caller 先 escape。
-    ///
-    /// **無 `white-space: pre-line` style**（2026-06 拔掉）：原本為純文字 `\n` 換行設計的 legacy CSS；
-    /// HTML 時代由 HTML 結構自身（`<p>` / `<br>` / `<h*>` 等）控制換行，`pre-line` 會把 HTMLFormatter
-    /// 在 block tag 之間插入的實體 `\n` 顯示為**多餘可見換行**、造成大段空白。caller 若仍有純文字
-    /// `\n` 需求，應自行轉 `<br>`；本欄位不再做隱性 `\n` → 換行的 magic。
+    /// **語意變更（2026-06）**：
+    /// 1. 原為純文字 `Text()` rendering、escape HTML chars；frontend 引入富文字編輯（粗體 / 底線 /
+    ///    刪除線 / 圖片 / 表格等）後改為 HTML。既有純文字 caller 仍可正常渲染（無 HTML tag 即等同純文字），
+    ///    但若內含 `<` `>` `&` 等 HTML 字元需 caller 先 escape。
+    /// 2. **拔掉硬寫的 `*` 前綴**：原 `"*\(supplementaryNote)"` 純文字時代的視覺標記，富文字時代由前端
+    ///    編輯器 / caller 自行決定是否在 content 內加 `*`（或其他 marker）。直接 prepend 會跟 caller 已
+    ///    寫入內容的 leading `*` 重疊，且當 caller HTML 開頭是 block element（如 `<style>` 加 wrapper
+    ///    `<div>`）時 `*` 文字節點會被擠到自己一行造成版面 bug。本欄位不再做任何隱性前綴 magic。
+    /// 3. **無 `white-space: pre-line` style**：原本為純文字 `\n` 換行設計的 legacy CSS；HTML 時代由
+    ///    HTML 結構自身（`<p>` / `<br>` / `<h*>` 等）控制換行，`pre-line` 會把 HTMLFormatter 在 block
+    ///    tag 之間插入的實體 `\n` 顯示為**多餘可見換行**、造成大段空白。caller 若仍有純文字 `\n`
+    ///    需求，應自行轉 `<br>`；本欄位不再做隱性 `\n` → 換行的 magic。
     public let supplementaryNote: String?
 
     public var body: any Component{
@@ -44,7 +48,7 @@ public struct Payment: Component {
             if let supplementaryNote, !supplementaryNote.isEmpty {
                 TableRow{
                     TableCell()  // alignment 占位，對齊 (n) 編號欄
-                    TableCell(html: "*\(supplementaryNote)")
+                    TableCell(html: supplementaryNote)
                         .attribute(named: "colspan", value: "2")
                         .style("padding-top: 0.5em;")
                 }

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -96,13 +96,14 @@ import Foundation
         ],
         supplementaryNote: "財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"
     )
-    // 2026-06：拔掉 `white-space: pre-line` legacy style — HTML 時代由 HTML 結構控制換行
-    // （caller 自行傳 `<br>` / `<p>` 等）；本 row 保留 `padding-top: 0.5em` 與 `*` 前綴 + `colspan="2"`。
+    // 2026-06：拔掉 `white-space: pre-line` legacy style + 拔掉硬寫的 `*` 前綴 — HTML 時代由
+    // caller 決定 marker / 換行；本 row 保留 `padding-top: 0.5em` 與 `colspan="2"`。
     let rendered = payment.render()
-    #expect(rendered.contains("*財務簽證依預估資產總額新台幣壹億元報價"))
+    #expect(rendered.contains("財務簽證依預估資產總額新台幣壹億元報價"))
     #expect(rendered.contains("padding-top: 0.5em"))
     #expect(rendered.contains("colspan=\"2\""))
     #expect(!rendered.contains("white-space: pre-line"), "legacy pre-line style 不應再被 emit")
+    #expect(!rendered.contains(">*財務簽證"), "硬寫的 `*` 前綴不應再被 emit — caller 自行決定 marker")
 }
 
 @Test func paymentOmitsSupplementaryNoteRowWhenNil(){
@@ -110,8 +111,8 @@ import Foundation
         name: "X",
         items: [.init(names: ["item"], fee: "1 元/年")]
     )
-    // 不渲染 supplementaryNote row 時，不會出現 `*` 前綴文字（其他 row 用編號 (1)(2)... 不用 `*`）
-    #expect(!payment.render().contains(">*"))
+    // nil → 整個 supplementaryNote row 不渲染（用 `colspan="2"` 鎖、items row 沒這屬性）
+    #expect(!payment.render().contains("colspan=\"2\""))
 }
 
 @Test func paymentOmitsSupplementaryNoteRowWhenEmptyString(){
@@ -120,10 +121,10 @@ import Foundation
         items: [.init(names: ["item"], fee: "1 元/年")],
         supplementaryNote: ""
     )
-    #expect(!payment.render().contains(">*"))
+    #expect(!payment.render().contains("colspan=\"2\""))
 }
 
-/// 鎖 supplementaryNote 走 raw HTML inject — 內含 `<b>` / `<u>` 等 tag 不會被 escape。
+/// 鎖 supplementaryNote 走 raw HTML inject — 內含 `<b>` / `<u>` 等 tag 不會被 escape，且**不加任何前綴**。
 /// 對應 2026-06 富文字編輯支援（前端 markdown / HTML 混合內容轉 HTML 後傳入此欄位）。
 @Test func paymentRendersSupplementaryNoteAsRawHTML(){
     let payment = Payment(
@@ -132,9 +133,10 @@ import Foundation
         supplementaryNote: "<b>粗體</b> <u>底線</u> <s>刪除線</s>"
     )
     let rendered = payment.render()
-    #expect(rendered.contains("*<b>粗體</b> <u>底線</u> <s>刪除線</s>"),
+    #expect(rendered.contains("<b>粗體</b> <u>底線</u> <s>刪除線</s>"),
         "HTML tag 應原樣 inject、不應被 escape 成 &lt;b&gt; 等")
     #expect(!rendered.contains("&lt;b&gt;"), "確認沒 escape")
+    #expect(!rendered.contains("*<b>"), "硬寫的 `*` 前綴不應再被 emit")
 }
 
 /// 鎖內嵌圖片（caller 已轉 data URI）正常 inject — `<img src="data:image/...">`。

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -100,8 +100,10 @@ import Foundation
     // caller 決定 marker / 換行；本 row 保留 `padding-top: 0.5em` 與 `colspan="2"`。
     let rendered = payment.render()
     #expect(rendered.contains("財務簽證依預估資產總額新台幣壹億元報價"))
-    #expect(rendered.contains("padding-top: 0.5em"))
-    #expect(rendered.contains("colspan=\"2\""))
+    // `colspan="2"` + `padding-top: 0.5em` 組合鎖補充說明 cell — 單獨 `padding-top: 0.5em` 會被
+    // item row 的 style 誤命中（item row 也含此 declaration）；`colspan="2"` 是補充說明 row 唯一特徵。
+    #expect(rendered.contains("colspan=\"2\" style=\"padding-top: 0.5em;\""),
+        "補充說明 cell 應保留 padding-top（搭 colspan=2 與 item row 區隔）")
     #expect(!rendered.contains("white-space: pre-line"), "legacy pre-line style 不應再被 emit")
     #expect(!rendered.contains(">*財務簽證"), "硬寫的 `*` 前綴不應再被 emit — caller 自行決定 marker")
 }

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -96,11 +96,13 @@ import Foundation
         ],
         supplementaryNote: "財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"
     )
-    // 多行 \n 在 HTML 中保留為 \n，由 `white-space: pre-line;` style 在渲染時轉成換行。
+    // 2026-06：拔掉 `white-space: pre-line` legacy style — HTML 時代由 HTML 結構控制換行
+    // （caller 自行傳 `<br>` / `<p>` 等）；本 row 保留 `padding-top: 0.5em` 與 `*` 前綴 + `colspan="2"`。
     let rendered = payment.render()
-    #expect(rendered.contains("*財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"))
-    #expect(rendered.contains("white-space: pre-line"))
+    #expect(rendered.contains("*財務簽證依預估資產總額新台幣壹億元報價"))
+    #expect(rendered.contains("padding-top: 0.5em"))
     #expect(rendered.contains("colspan=\"2\""))
+    #expect(!rendered.contains("white-space: pre-line"), "legacy pre-line style 不應再被 emit")
 }
 
 @Test func paymentOmitsSupplementaryNoteRowWhenNil(){
@@ -108,7 +110,8 @@ import Foundation
         name: "X",
         items: [.init(names: ["item"], fee: "1 元/年")]
     )
-    #expect(!payment.render().contains("white-space: pre-line"))
+    // 不渲染 supplementaryNote row 時，不會出現 `*` 前綴文字（其他 row 用編號 (1)(2)... 不用 `*`）
+    #expect(!payment.render().contains(">*"))
 }
 
 @Test func paymentOmitsSupplementaryNoteRowWhenEmptyString(){
@@ -117,7 +120,7 @@ import Foundation
         items: [.init(names: ["item"], fee: "1 元/年")],
         supplementaryNote: ""
     )
-    #expect(!payment.render().contains("white-space: pre-line"))
+    #expect(!payment.render().contains(">*"))
 }
 
 /// 鎖 supplementaryNote 走 raw HTML inject — 內含 `<b>` / `<u>` 等 tag 不會被 escape。


### PR DESCRIPTION
## Summary

純文字時代 `Payment.supplementaryNote` 有兩條為當時設計的 magic、富文字時代都已不該存在：

1. **`white-space: pre-line`** — 純文字 `\n` 換行設計，富文字時代由 HTML 結構自身（`<br>` / `<p>` / `<h*>` 等）控制換行
2. **硬寫的 `*` 前綴**（`"*\(supplementaryNote)"`）— 純文字時代的視覺標記，富文字時代由 caller 完全決定

## 實際 bug

**`pre-line`**：HTMLFormatter（OC 端 swift-markdown）在 block tag 之間插入實體 `\n`，`pre-line` 把這些 `\n` 顯示為**多餘可見換行** → PDF 上每個 block 之間出現大段空白，表格與圖片被推到後面好幾頁（user 報的 bug）。

**硬寫的 `*` 前綴**：
- caller 已寫入內容若也以 `*` 開頭（前端 TipTap callout 序列化常見）→ 出現雙 `*`
- caller 內容若起始為 block element（如 scoped `<style>` 加 wrapper `<div>`）→ `*` 文字節點被擠到自己一行、與內容不同行

OC composer 側會配合加 scoped CSS（表格框線、`<h*>` margin reset 等 HTMLFormatter 預設 margin 收斂）。

## 變更

- `Payment.body` 內 supplementaryNote row 拔掉 `white-space: pre-line` style
- `TableCell(html: "*\(supplementaryNote)")` → `TableCell(html: supplementaryNote)` 拔掉硬寫前綴
- `supplementaryNote` 屬性 docstring 重寫：caller 完全決定 marker / 換行 / 版面，本欄位不再做任何隱性 magic

## Test plan

- [x] `paymentRendersSupplementaryNoteRowWhenProvided` assertion：contains content + padding-top + colspan="2"，**不含** pre-line、**不含** 硬寫 `*` 前綴
- [x] `paymentOmitsSupplementaryNoteRowWhenNil/EmptyString` 改鎖 `colspan="2"` 唯一屬性
- [x] `paymentRendersSupplementaryNoteAsRawHTML` 補 `*<b>` negative assertion
- [x] 既有 `WithEmbeddedImage` 通過

## 後續

Merge 完 tag `1.23.0`、OC `dev/fixSupplementaryNoteSubstitution` 已 prep 好 scoped CSS（表格框線 + img max-width）等 bump 依賴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)