### PR TITLE
[REFACTOR] 報價 presentation 內聚到 PDFGenerator：fee label + supplementaryNote markdown + 分隔線

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -10,12 +10,30 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
         "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
         "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
+        "version" : "0.8.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/SwiftPackageIndex/Plot.git", from: "0.14.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
+        // swift-markdown — supplementaryNote 富文字 markdown → HTML 渲染用（presentation 歸 PDFGenerator）
+        .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.6.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -24,7 +26,8 @@ let package = Package(
         .target(
             name: "QuotationHTML",
             dependencies: [
-                .product(name: "Plot", package: "plot")
+                .product(name: "Plot", package: "plot"),
+                .product(name: "Markdown", package: "swift-markdown")
             ], resources: [
                 .copy("Resources/header/quotation-header-01020314.png"),
                 .copy("Resources/footer/quotation-footer-01020314.png"),

--- a/Sources/Main/main.swift
+++ b/Sources/Main/main.swift
@@ -48,12 +48,12 @@ let assistance = BusinessClientAssistance.Model(title: "貴公司之協助辦理
 
 //print("\n")
 let paymentItems: [PaymentItem.Model] = [
-    .init(names: ["工商登記處理作業(資本額200萬元)(台中市)(不含動資查核)(股東3人)"], fee: "16,000 元/次"),
-    .init(names: ["會計帳務及稅務申報處理作業-書審 (設立完成後開始)"], fee: "優惠免收"),
-    .init(names: ["附設補習班-會計帳務及其稅務申報處理作業-書審(設立完成後開始)"], fee: "1,000 元/月")
+    .init(names: ["工商登記處理作業(資本額200萬元)(台中市)(不含動資查核)(股東3人)"], fee: .oneTime(16000)),
+    .init(names: ["會計帳務及稅務申報處理作業-書審 (設立完成後開始)"], fee: .oneTime(0)),
+    .init(names: ["附設補習班-會計帳務及其稅務申報處理作業-書審(設立完成後開始)"], fee: .monthly(1000))
 ]
 let paymentItems2: [PaymentItem.Model] = [
-    .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: "5000 元/月"),
+    .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: .monthly(5000)),
 ]
 
 

--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -11,25 +11,15 @@ public struct Payment: Component {
     public let items: [PaymentItem]
     public let needShowName: Bool
     /// 酬金補充說明（per-case 註解）。
-    /// **HTML 字串**（非純文字）— 整段以 raw HTML inject 到 `<td>`，不做 HTML escape、不加任何前綴。
-    /// caller（OC composer）負責把 markdown + 內嵌 HTML 轉成乾淨 HTML 字串（含內嵌圖片轉 data URI、
-    /// template variable 替換等）+ 內嵌 scoped `<style>` block 控版面後傳入。
+    /// **markdown 字串** — 由 PDFGenerator 內部 `SupplementaryNoteHTMLRenderer` 渲染成 HTML
+    /// （markdown → HTML + soft break 換行 + scoped style）後 inject 到 `<td>`。
+    /// caller（OC）只做領域 / 安全前處理：template variable 替換成實際值、內嵌圖片 fetch + ownership
+    /// 驗證後 inline 成 `<img data:...>`；**不做 markdown→HTML、不傳 CSS、不加 marker**（presentation 全歸此處）。
     /// `nil` 或空字串 → 不渲染此 row。
     ///
-    /// **語意變更（2026-06）**：
-    /// 1. 原為純文字 `Text()` rendering、escape HTML chars；frontend 引入富文字編輯（粗體 / 底線 /
-    ///    刪除線 / 圖片 / 表格等）後改為 HTML。既有純文字 caller 仍可正常渲染（無 HTML tag 即等同純文字），
-    ///    但若內含 `<` `>` `&` 等 HTML 字元需 caller 先 escape。
-    /// 2. **拔掉硬寫的 `*` 前綴**：原 `"*\(supplementaryNote)"` 純文字時代的視覺標記，富文字時代由前端
-    ///    編輯器 / caller 自行決定是否在 content 內加 `*`（或其他 marker）。直接 prepend 會跟 caller 已
-    ///    寫入內容的 leading `*` 重疊，且當 caller HTML 開頭是 block element（如 `<style>` 加 wrapper
-    ///    `<div>`）時 `*` 文字節點會被擠到自己一行造成版面 bug。本欄位不再做任何隱性前綴 magic。
-    /// 3. **無 `white-space: pre-line` style**：原本為純文字 `\n` 換行設計的 legacy CSS；HTML 時代由
-    ///    HTML 結構自身（`<p>` / `<br>` / `<h*>` 等）控制換行，`pre-line` 會把 HTMLFormatter 在 block
-    ///    tag 之間插入的實體 `\n` 顯示為**多餘可見換行**、造成大段空白。caller 若仍有純文字 `\n`
-    ///    需求，應自行轉 `<br>`；本欄位不再做隱性 `\n` → 換行的 magic。
-    /// 4. **上方分隔線（2026-06）**：補充說明 row 帶 row-level `border-top: 1px solid black`，
-    ///    與 `PaymentBlock` 表頭分隔線同手法（`border-collapse` 下跨整欄），取代舊 `*` marker 的視覺分隔功能。
+    /// **渲染重點**：
+    /// - 補充說明 row 兩個 cell 帶 `border-top: 1px solid black` → 上方一條跨整欄分隔線（取代舊 `*` marker）。
+    /// - markdown / 樣式細節見 `SupplementaryNoteHTMLRenderer`。
     public let supplementaryNote: String?
 
     public var body: any Component{
@@ -51,10 +41,11 @@ public struct Payment: Component {
                 // 補充說明上方一條橫線：border 下在 **cell** 而非 row —— border-collapse 下 weasyprint
                 // 對非首列的 row-level border-top 不穩（會與前一列 border 塌掉而不畫），cell border 才可靠。
                 // 兩個 cell（占位 + colspan=2）都加 → 跨整欄、視覺等同 PaymentBlock 表頭分隔線。
+                // markdown → HTML 在此渲染（presentation 歸 PDFGenerator）；caller 傳的是 markdown。
                 TableRow{
                     TableCell()  // alignment 占位，對齊 (n) 編號欄
                         .style("border-top: 1px solid black;")
-                    TableCell(html: supplementaryNote)
+                    TableCell(html: SupplementaryNoteHTMLRenderer.render(markdown: supplementaryNote))
                         .attribute(named: "colspan", value: "2")
                         .style("border-top: 1px solid black; padding-top: 0.5em;")
                 }

--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -28,6 +28,8 @@ public struct Payment: Component {
     ///    HTML 結構自身（`<p>` / `<br>` / `<h*>` 等）控制換行，`pre-line` 會把 HTMLFormatter 在 block
     ///    tag 之間插入的實體 `\n` 顯示為**多餘可見換行**、造成大段空白。caller 若仍有純文字 `\n`
     ///    需求，應自行轉 `<br>`；本欄位不再做隱性 `\n` → 換行的 magic。
+    /// 4. **上方分隔線（2026-06）**：補充說明 row 帶 row-level `border-top: 1px solid black`，
+    ///    與 `PaymentBlock` 表頭分隔線同手法（`border-collapse` 下跨整欄），取代舊 `*` marker 的視覺分隔功能。
     public let supplementaryNote: String?
 
     public var body: any Component{
@@ -46,11 +48,15 @@ public struct Payment: Component {
                 }.style("padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;")
             }
             if let supplementaryNote, !supplementaryNote.isEmpty {
+                // 補充說明上方一條橫線：border 下在 **cell** 而非 row —— border-collapse 下 weasyprint
+                // 對非首列的 row-level border-top 不穩（會與前一列 border 塌掉而不畫），cell border 才可靠。
+                // 兩個 cell（占位 + colspan=2）都加 → 跨整欄、視覺等同 PaymentBlock 表頭分隔線。
                 TableRow{
                     TableCell()  // alignment 占位，對齊 (n) 編號欄
+                        .style("border-top: 1px solid black;")
                     TableCell(html: supplementaryNote)
                         .attribute(named: "colspan", value: "2")
-                        .style("padding-top: 0.5em;")
+                        .style("border-top: 1px solid black; padding-top: 0.5em;")
                 }
             }
         }

--- a/Sources/QuotationHTML/PaymentItem.swift
+++ b/Sources/QuotationHTML/PaymentItem.swift
@@ -5,12 +5,50 @@
 //  Created by Grady Zhuo on 2024/9/23.
 //
 
+import Foundation
 import Plot
 
 public struct PaymentItem: Component{
     let names: [String]
-    let fee: String
-    
+    let fee: Fee
+
+    /// 酬金金額表達。
+    ///
+    /// `amount`（各 case 的關聯值）是**領域值**：caller（OC）只給「月收 / 年收 / 一次性 + 金額」，
+    /// 其中 monthly 金額已由 caller 正規化為前 12 月一致的單月金額（業務算法）。
+    ///
+    /// 顯示成什麼樣子——千分位、`/次` `/月` `/年` 後綴、金額 0 顯示「優惠免收」——全由 `displayText`
+    /// 決定，**屬 presentation、歸 PDFGenerator**；caller 不應自行組顯示字串。
+    public enum Fee: Sendable, Equatable {
+        case oneTime(Decimal)
+        case yearly(Decimal)
+        case monthly(Decimal)
+
+        /// PDF 顯示字串：`amount == 0` → 「優惠免收」；否則「{千分位金額} 元{/次|/月|/年}」。
+        public var displayText: String {
+            let amount: Decimal
+            let suffix: String
+            switch self {
+            case .oneTime(let value): amount = value; suffix = "/次"
+            case .yearly(let value): amount = value; suffix = "/年"
+            case .monthly(let value): amount = value; suffix = "/月"
+            }
+            if amount == 0 { return "優惠免收" }
+            return "\(Self.formatAmount(amount)) 元\(suffix)"
+        }
+
+        /// 千分位、無小數（金額為整數元）。
+        private static func formatAmount(_ amount: Decimal) -> String {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.minimumFractionDigits = 0
+            formatter.maximumFractionDigits = 0
+            formatter.groupingSeparator = ","
+            formatter.groupingSize = 3
+            return formatter.string(from: amount as NSDecimalNumber) ?? "\(amount)"
+        }
+    }
+
     var lines: [String] {
         get {
             names.flatMap {
@@ -18,7 +56,7 @@ public struct PaymentItem: Component{
             }
         }
     }
-    
+
     public var body: any Component{
         ComponentGroup{
             TableCell{
@@ -29,18 +67,12 @@ public struct PaymentItem: Component{
                 }
             }
             TableCell{
-                Text(fee)
+                Text(fee.displayText)
             }.style("text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;")
         }
     }
-    
-    @available(*, deprecated, message: "use init(names:fee:) instead.")
-    public init(names: [String], price: String, billingPeriod: String) {
-        self.names = names
-        self.fee = "\(price) \(billingPeriod.description)"
-    }
-    
-    public init(names: [String], fee: String) {
+
+    public init(names: [String], fee: Fee) {
         self.names = names
         self.fee = fee
     }
@@ -49,9 +81,9 @@ public struct PaymentItem: Component{
 extension PaymentItem {
     public struct Model {
         let names: [String]
-        let fee: String
-        
-        public init(names: [String], fee: String) {
+        let fee: Fee
+
+        public init(names: [String], fee: Fee) {
             self.names = names
             self.fee = fee
         }

--- a/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
+++ b/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
@@ -29,7 +29,7 @@ public struct ReplyFormPaymentBlock: Component {
                                 }
                             }.style("vertical-align: top; width: 100%;")
                             TableCell{
-                                Text("\(item.fee)")
+                                Text(item.fee.displayText)
                             }.style("vertical-align: top; text-align: right; white-space: nowrap;")
                         }
                     }

--- a/Sources/QuotationHTML/SupplementaryNoteHTMLRenderer.swift
+++ b/Sources/QuotationHTML/SupplementaryNoteHTMLRenderer.swift
@@ -1,0 +1,52 @@
+//
+//  SupplementaryNoteHTMLRenderer.swift
+//  PDFGenerator
+//
+//  把酬金補充說明的 markdown 渲染成 PDF 用 HTML — presentation 歸 PDFGenerator。
+//
+
+import Foundation
+import Markdown
+
+/// 把補充說明 markdown 轉成 HTML 字串（含 scoped style）。
+///
+/// **職責邊界**：caller（OC）只負責「領域 / 安全」前處理 —— template variable 替換成實際值、
+/// 內嵌圖片 fetch + ownership 驗證後 inline 成 `<img data:...>`。markdown → HTML 的渲染與所有
+/// 版面樣式（換行規則、表格框線、圖片縮放、block 間距）都在這裡，屬 PDFGenerator 的 presentation。
+///
+/// 渲染規則：
+/// - **soft break → `<br>`**：段落內單一 `\n` 轉硬換行，讓「多句各佔一行」確實換行；`\n\n` 仍是段落。
+/// - **scoped `<style>`**：`.rich-supplementaryNote` class scope，不污染 PDF 其他 section。
+///   表格補框線（weasyprint 預設無框）、圖片限寬避免爆版、block element（`<p>`/`<h*>`/`<ul>`/`<ol>`）
+///   margin 歸零讓標題與一般段落行距一致。
+enum SupplementaryNoteHTMLRenderer {
+
+    static func render(markdown: String) -> String {
+        let document = Document(parsing: markdown)
+        var rewriter = SoftBreakToLineBreakRewriter()
+        let rewritten = rewriter.visit(document) ?? document
+        let body = HTMLFormatter.format(rewritten)
+        return scopedStyleBlock + "<div class=\"rich-supplementaryNote\">\(body)</div>"
+    }
+
+    static let scopedStyleBlock: String = """
+    <style>
+    .rich-supplementaryNote table { border-collapse: collapse; }
+    .rich-supplementaryNote table td,
+    .rich-supplementaryNote table th { border: 1px solid #999; padding: 0.15em 0.5em; }
+    .rich-supplementaryNote img { max-width: 200px; height: auto; }
+    .rich-supplementaryNote p,
+    .rich-supplementaryNote h1, .rich-supplementaryNote h2, .rich-supplementaryNote h3,
+    .rich-supplementaryNote h4, .rich-supplementaryNote h5, .rich-supplementaryNote h6,
+    .rich-supplementaryNote ul, .rich-supplementaryNote ol { margin: 0; }
+    </style>
+    """
+}
+
+/// 把 markdown AST 的 `SoftBreak`（段落內單一 `\n`）改寫成 `LineBreak`（HTML `<br>`）。
+/// `\n\n`（段落分隔）是 paragraph boundary、不是 SoftBreak node，不受影響。
+private struct SoftBreakToLineBreakRewriter: MarkupRewriter {
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> Markup? {
+        LineBreak()
+    }
+}

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -102,8 +102,8 @@ import Foundation
     #expect(rendered.contains("財務簽證依預估資產總額新台幣壹億元報價"))
     // `colspan="2"` + `padding-top: 0.5em` 組合鎖補充說明 cell — 單獨 `padding-top: 0.5em` 會被
     // item row 的 style 誤命中（item row 也含此 declaration）；`colspan="2"` 是補充說明 row 唯一特徵。
-    #expect(rendered.contains("colspan=\"2\" style=\"padding-top: 0.5em;\""),
-        "補充說明 cell 應保留 padding-top（搭 colspan=2 與 item row 區隔）")
+    #expect(rendered.contains("colspan=\"2\" style=\"border-top: 1px solid black; padding-top: 0.5em;\""),
+        "補充說明 cell 應帶上方分隔線 + 保留 padding-top（搭 colspan=2 與 item row 區隔）")
     #expect(!rendered.contains("white-space: pre-line"), "legacy pre-line style 不應再被 emit")
     #expect(!rendered.contains(">*財務簽證"), "硬寫的 `*` 前綴不應再被 emit — caller 自行決定 marker")
 }

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -62,7 +62,7 @@ import Foundation
 
 @Test func createPaymentItemHtml(){
     let names: [String] = ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證", "二代健保暨表單彙總處理"]
-    let fee: String = "5,000 元/月"
+    let fee: PaymentItem.Fee = .monthly(5000)
     
     let paymentItem = PaymentItem(names: names, fee: fee)
     
@@ -78,8 +78,8 @@ import Foundation
 @Test func createPaymentHtml(){
     let title = "酬金"
     let items: [PaymentItem] = [
-        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"], fee: "5,000 元/年"),
-        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: "6,000 元/年")
+        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"], fee: .yearly(5000)),
+        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: .yearly(6000))
     ]
 
     let payment = Payment(name: title, items: items)
@@ -92,7 +92,7 @@ import Foundation
     let payment = Payment(
         name: "糕盛有限公司",
         items: [
-            .init(names: ["民國 114 度財務報表查核簽證"], fee: "100,000 元/年")
+            .init(names: ["民國 114 度財務報表查核簽證"], fee: .yearly(100000))
         ],
         supplementaryNote: "財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"
     )
@@ -111,7 +111,7 @@ import Foundation
 @Test func paymentOmitsSupplementaryNoteRowWhenNil(){
     let payment = Payment(
         name: "X",
-        items: [.init(names: ["item"], fee: "1 元/年")]
+        items: [.init(names: ["item"], fee: .yearly(1))]
     )
     // nil → 整個 supplementaryNote row 不渲染（用 `colspan="2"` 鎖、items row 沒這屬性）
     #expect(!payment.render().contains("colspan=\"2\""))
@@ -120,7 +120,7 @@ import Foundation
 @Test func paymentOmitsSupplementaryNoteRowWhenEmptyString(){
     let payment = Payment(
         name: "X",
-        items: [.init(names: ["item"], fee: "1 元/年")],
+        items: [.init(names: ["item"], fee: .yearly(1))],
         supplementaryNote: ""
     )
     #expect(!payment.render().contains("colspan=\"2\""))
@@ -131,7 +131,7 @@ import Foundation
 @Test func paymentRendersSupplementaryNoteAsRawHTML(){
     let payment = Payment(
         name: "X",
-        items: [.init(names: ["item"], fee: "1 元/年")],
+        items: [.init(names: ["item"], fee: .yearly(1))],
         supplementaryNote: "<b>粗體</b> <u>底線</u> <s>刪除線</s>"
     )
     let rendered = payment.render()
@@ -146,7 +146,7 @@ import Foundation
     let dataUri = "data:image/png;base64,iVBORw0KGgo=" // 短的測試用 base64
     let payment = Payment(
         name: "X",
-        items: [.init(names: ["item"], fee: "1 元/年")],
+        items: [.init(names: ["item"], fee: .yearly(1))],
         supplementaryNote: "見附圖：<img src=\"\(dataUri)\" />"
     )
     let rendered = payment.render()
@@ -157,18 +157,18 @@ import Foundation
 @Test("two payment", arguments: [
     ([
         Payment(name: "****作業(112 年度)", items: [
-            .init(names: ["Hello"], fee: "5,000 元/月")
+            .init(names: ["Hello"], fee: .monthly(5000))
         ]),
         Payment(name: "****作業(113 年起)", items: [
-            .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"], fee: "5,000 元/年"),
-            .init(names: ["World"], fee: "6,000 元/年")
+            .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"], fee: .yearly(5000)),
+            .init(names: ["World"], fee: .yearly(6000))
         ])
     ], """
     <p style="font-size: 1.1rem;">酬金</p><table style="border-collapse: collapse; width: 100%;"><tr style="border-bottom: 1px solid black;"><td colspan="2" style="text-align: center ;">服務項目</td><td><div style="white-space: nowrap; text-align: right; padding-right: 1em;">公費金額</div></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td colspan="3"><b style="font-size: 1.1em;">****作業(112 年度)</b></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>Hello</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/月</td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td colspan="3"><b style="font-size: 1.1em;">****作業(113 年起)</b></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(2)</td><td><div>World</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">6,000 元/年</td></tr></table>
     """),
     ([
         Payment(name: "****作業(112 年度)", items: [
-            .init(names: ["Hello"], fee: "5,000 元/年")
+            .init(names: ["Hello"], fee: .yearly(5000))
         ])
     ], """
     <p style="font-size: 1.1rem;">酬金</p><table style="border-collapse: collapse; width: 100%;"><tr style="border-bottom: 1px solid black;"><td colspan="2" style="text-align: center ;">服務項目</td><td><div style="white-space: nowrap; text-align: right; padding-right: 1em;">公費金額</div></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>Hello</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr></table>
@@ -228,8 +228,8 @@ func createPaymentBlocHtml(payments: [Payment], result: String){
     let sender = "88183980"
     let subject = "本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。"
     let paymentItems: [PaymentItem] = [
-        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"],  fee: "5,000 元/年"),
-        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: "6,000 元/月")
+        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"],  fee: .yearly(5000)),
+        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: .monthly(6000))
     ]
     let payments = [
         Payment(name: "Hello", items: paymentItems)
@@ -252,8 +252,8 @@ func createPaymentBlocHtml(payments: [Payment], result: String){
     let sender = "88183980"
     let subject = "本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。"
     let paymentItems: [PaymentItem] = [
-        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"],  fee: "5,000 元/年"),
-        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: "6,000 元/月")
+        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"],  fee: .yearly(5000)),
+        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: .monthly(6000))
     ]
     let payments = [
         Payment(name: "Hello", items: paymentItems)
@@ -276,8 +276,8 @@ func createPaymentBlocHtml(payments: [Payment], result: String){
     let subject = "本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。"
     
     let paymentItems: [PaymentItem] = [
-        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"], fee: "5,000 元/年"),
-        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: "6,000 元/月")
+        .init(names: ["民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證"], fee: .yearly(5000)),
+        .init(names: ["會計帳務處理作業（113 年 5 月開始）"], fee: .monthly(6000))
     ]
     
     let payments = [


### PR DESCRIPTION
## 概要

把原本散在 OpportunityContext 的「報價單長相」邏輯收回 PDFGenerator，讓 presentation 歸 PDFGenerator、OC 只負責給領域資料。**API breaking**：caller（OC）需同步改傳 fee kind + 金額、傳 markdown。

## 變更內容

### 1. fee label 內聚（`9e55c41`）
- `PaymentItem.fee`：`String` → `PaymentItem.Fee` enum（`oneTime` / `yearly` / `monthly` + `Decimal`）。
- 千分位、`元/次`「元/月」「元/年」後綴、`0 → 優惠免收` 全部由 `Fee.displayText` 內算（原本由 OC caller 先組好字串傳入）。

### 2. supplementaryNote 改用 markdown（`9e55c41`）
- `Payment.supplementaryNote` 從語意 HTML 改為 **markdown**。
- 新增 `SupplementaryNoteHTMLRenderer`：markdown → HTML + soft break（單 `\n`）轉 `<br>` + scoped `<style>`（table 框線 / img 限寬 / `<p>`/`<h*>`/`<ul>`/`<ol>` margin 歸零）。
- 新增 swift-markdown 依賴。

### 3. supplementaryNote 上方分隔線（`1708fce`）
- 補充說明 row 兩個 cell 加 `border-top: 1px solid black`，視覺等同 PaymentBlock 表頭分隔線，取代舊 `*` marker 的視覺分隔功能。
- border 下在 **cell** 而非 row：weasyprint 在 border-collapse 下對非首列 row-level border-top 不穩，cell border 才可靠跨整欄。

## 對應 OC 端
改傳 kind + 金額（不組字串）、傳 markdown（不先轉 HTML）—— 對應 OpportunityContext branch `dev/quotationPdfRenderingFixes`。

## 測試
`Tests/PDFGeneratorTests/PDFGeneratorTests.swift` 同步更新 fee + markdown 語意；`paymentRendersSupplementaryNoteRowWhenProvided` assert cell border-top + padding-top。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發行說明

* **新功能**
  * 補充說明現支援 Markdown 格式，提供更靈活的文本編輯與呈現

* **改進**
  * 付款費用顯示升級：新增千分位格式化與自動計費週期標記
  * 付款表格視覺優化：改進邊框分隔線與間距樣式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->