### PR TITLE
[ADD] 酬金多 case 時顯示 case 名稱標題（bundle 名標題落在其下）

### DIFF
--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -10,6 +10,11 @@ public struct Payment: Component {
     public let name: String
     public let items: [PaymentItem]
     public let needShowName: Bool
+    /// 此 bundle 所屬 quotingCase 的名稱。多 case（≥2 個不同 `caseName`）時 `PaymentBlock` /
+    /// `ReplyFormPaymentBlock` 會在該 case 第一個 bundle 上方渲染 case 名稱標題（bundle 名標題落在其下）；
+    /// 單一 case 時不渲染 case 標題（沿用既有單/多 bundle 行為）。`nil` 視為「無 case 維度」（= 單 case）。
+    /// **是否顯示** case 標題是 presentation 判斷，由本 lib 依 caseName 分組數決定，caller 只忠實提供值。
+    public let caseName: String?
     /// 酬金補充說明（per-case 註解）。
     /// **markdown 字串** — 由 PDFGenerator 內部 `SupplementaryNoteHTMLRenderer` 渲染成 HTML
     /// （markdown → HTML + soft break 換行 + scoped style）後 inject 到 `<td>`。
@@ -53,15 +58,16 @@ public struct Payment: Component {
         }
     }
 
-    public init(name: String, items: [PaymentItem], needShowName: Bool = true, supplementaryNote: String? = nil) {
+    public init(name: String, items: [PaymentItem], needShowName: Bool = true, supplementaryNote: String? = nil, caseName: String? = nil) {
         self.name = name
         self.items = items
         self.needShowName = needShowName
         self.supplementaryNote = supplementaryNote
+        self.caseName = caseName
     }
 
     package func hideName() -> Self {
-        .init(name: name, items: items, needShowName: false, supplementaryNote: supplementaryNote)
+        .init(name: name, items: items, needShowName: false, supplementaryNote: supplementaryNote, caseName: caseName)
     }
 }
 
@@ -71,12 +77,14 @@ extension Payment {
         public let items: [PaymentItem.Model]
         public let needShowName: Bool
         public let supplementaryNote: String?
+        public let caseName: String?
 
-        public init(name: String, items: [PaymentItem.Model], needShowName: Bool, supplementaryNote: String? = nil) {
+        public init(name: String, items: [PaymentItem.Model], needShowName: Bool, supplementaryNote: String? = nil, caseName: String? = nil) {
             self.name = name
             self.items = items
             self.needShowName = needShowName
             self.supplementaryNote = supplementaryNote
+            self.caseName = caseName
         }
     }
 }

--- a/Sources/QuotationHTML/PaymentBlock.swift
+++ b/Sources/QuotationHTML/PaymentBlock.swift
@@ -12,7 +12,9 @@ public struct PaymentBlock: Component {
     package let payments: [Payment]
     
     public var body: any Component{
-        ComponentGroup{
+        // ≥2 個不同 case 時，在每個 case 第一個 bundle 上方插入 case 名稱標題（bundle 名標題落在其下）。
+        let showCaseNames = PaymentCaseGrouping.showsCaseNames(payments)
+        return ComponentGroup{
             Paragraph(title).style("font-size: 1.1rem;")
             Table{
                 TableRow{
@@ -21,18 +23,31 @@ public struct PaymentBlock: Component {
                         Div("公費金額").style("white-space: nowrap; text-align: right; padding-right: 1em;")
                     }
                 }.style("border-bottom: 1px solid black;")
-                
-                for payment in payments {
-                    payment.style("font-size: 1rem; padding-bottom: 0.5em; width: 100%;")
+
+                for run in PaymentCaseGrouping.runs(payments) {
+                    if showCaseNames {
+                        TableRow{
+                            TableCell{
+                                Text(run.caseName ?? "").bold().style("font-size: 1.2em;")
+                            }.attribute(named: "colspan", value: "3")
+                        }.style("padding-top: 0.5em;")
+                    }
+                    for payment in run.payments {
+                        payment.style("font-size: 1rem; padding-bottom: 0.5em; width: 100%;")
+                    }
                 }
-                
+
             }.style("border-collapse: collapse; width: 100%;")
         }
     }
-    
+
     public init(title: String, payments: [Payment]) {
         self.title = title
-        self.payments = if payments.count == 1 {
+        // 單一 case 時沿用「單 bundle 不顯示 bundle 名」；多 case 時各 bundle 名都要顯示在 case 名底下，
+        // 故不套用單 bundle 隱藏（body 依 caseName 分組決定是否加 case 標題）。
+        self.payments = if PaymentCaseGrouping.showsCaseNames(payments) {
+            payments
+        } else if payments.count == 1 {
             payments.map{
                 $0.hideName()
             }

--- a/Sources/QuotationHTML/PaymentCaseGrouping.swift
+++ b/Sources/QuotationHTML/PaymentCaseGrouping.swift
@@ -1,0 +1,30 @@
+//
+//  PaymentCaseGrouping.swift
+//  PDFGenerator
+//
+//  酬金 payments 依 `caseName` 分組的 presentation 規則，供 `PaymentBlock` /
+//  `ReplyFormPaymentBlock` 共用。caller（OC）只忠實提供每個 bundle 的 `caseName`；
+//  「是否顯示 case 標題」是版面判斷，集中在此。
+//
+
+enum PaymentCaseGrouping {
+    /// 依 `caseName` 把連續同 case 的 payments 收成一段（OC 以 case→bundle 順序送入，故連續分組即可）。
+    /// 回傳順序與輸入一致。
+    static func runs(_ payments: [Payment]) -> [(caseName: String?, payments: [Payment])] {
+        var result: [(caseName: String?, payments: [Payment])] = []
+        for payment in payments {
+            if let lastIndex = result.indices.last, result[lastIndex].caseName == payment.caseName {
+                result[lastIndex].payments.append(payment)
+            } else {
+                result.append((caseName: payment.caseName, payments: [payment]))
+            }
+        }
+        return result
+    }
+
+    /// ≥2 個不同 case 分段時才顯示 case 名稱標題；單一 case（含 `caseName` 全 nil）不顯示，
+    /// 沿用各 block 既有的單/多 bundle 行為。
+    static func showsCaseNames(_ payments: [Payment]) -> Bool {
+        runs(payments).count > 1
+    }
+}

--- a/Sources/QuotationHTML/Quotation.swift
+++ b/Sources/QuotationHTML/Quotation.swift
@@ -179,7 +179,7 @@ extension AuditQuotation {
         let payments: [Payment.Model] = paymentBlock.payments.map{
             .init(name: $0.name, items: $0.items.map{
                 .init(names: $0.names, fee: $0.fee)
-            }, needShowName: $0.needShowName)
+            }, needShowName: $0.needShowName, caseName: $0.caseName)
         }
         let serviceScope: ServiceScope.Model = .init(title: serviceScope.title, heading: serviceScope.heading, items: serviceScope.items.map{
             $0.map{
@@ -204,7 +204,7 @@ extension AuditQuotation {
         let replyForm: ReplyForm.Model = .init(subject: replyForm.subject, payments: replyForm.payments.map{
             .init(name: $0.name, items: $0.items.map{
                 .init(names: $0.names, fee: $0.fee)
-            }, needShowName: $0.needShowName)
+            }, needShowName: $0.needShowName, caseName: $0.caseName)
         }, additionalServices: replyForm.additionalServices.map{
             .init(name: $0.name, isSelected: $0.isSelected)
         }, showCompanyStamp: replyForm.showCompanyStamp)

--- a/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
+++ b/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
@@ -11,26 +11,35 @@ public struct ReplyFormPaymentBlock: Component {
     let payments: [Payment]
 
     public var body: any Component {
-        ComponentGroup {
+        // 多 case 時與主酬金一致：每個 case 第一個 bundle 上方加 case 名稱標題。
+        let showCaseNames = PaymentCaseGrouping.showsCaseNames(payments)
+        return ComponentGroup {
             Table {
-                for payment in payments {
-                    if payment.needShowName {
+                for run in PaymentCaseGrouping.runs(payments) {
+                    if showCaseNames {
                         TableRow{
-                            TableCell(Text(payment.name).bold()).attribute(named: "colspan", value: "3").style("vertical-align: middle;")
+                            TableCell(Text(run.caseName ?? "").bold().style("font-size: 1.1em;")).attribute(named: "colspan", value: "3").style("vertical-align: middle;")
                         }
                     }
-                    
-                    for (index, item) in payment.items.enumerated() {
-                        TableRow {
-                            TableCell("(\(index+1))").style("vertical-align: top;")
-                            TableCell {
-                                for line in item.lines {
-                                    Div(line)
-                                }
-                            }.style("vertical-align: top; width: 100%;")
-                            TableCell{
-                                Text(item.fee.displayText)
-                            }.style("vertical-align: top; text-align: right; white-space: nowrap;")
+                    for payment in run.payments {
+                        if payment.needShowName {
+                            TableRow{
+                                TableCell(Text(payment.name).bold()).attribute(named: "colspan", value: "3").style("vertical-align: middle;")
+                            }
+                        }
+
+                        for (index, item) in payment.items.enumerated() {
+                            TableRow {
+                                TableCell("(\(index+1))").style("vertical-align: top;")
+                                TableCell {
+                                    for line in item.lines {
+                                        Div(line)
+                                    }
+                                }.style("vertical-align: top; width: 100%;")
+                                TableCell{
+                                    Text(item.fee.displayText)
+                                }.style("vertical-align: top; text-align: right; white-space: nowrap;")
+                            }
                         }
                     }
                 }

--- a/Sources/QuotationHTML/extension/Array+Payment.swift
+++ b/Sources/QuotationHTML/extension/Array+Payment.swift
@@ -12,7 +12,8 @@ extension Array where Element == Payment {
                 name: $0.name,
                 items: .init($0.items),
                 needShowName: $0.needShowName,
-                supplementaryNote: $0.supplementaryNote)
+                supplementaryNote: $0.supplementaryNote,
+                caseName: $0.caseName)
         }
     }
 }

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -176,8 +176,41 @@ import Foundation
 ])
 func createPaymentBlocHtml(payments: [Payment], result: String){
     let paymentBlock = PaymentBlock(title: "酬金", payments: payments)
-    
+
     #expect(paymentBlock.render() == result)
+}
+
+@Test("multiple cases render a case-name heading above each case's bundles")
+func paymentBlockRendersCaseHeadingsWhenMultipleCases() {
+    let payments = [
+        Payment(name: "規劃1", items: [.init(names: ["稅務帳務處理作業"], fee: .monthly(4000))], caseName: "甲公司"),
+        Payment(name: "規劃1", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(50000))], caseName: "乙公司"),
+    ]
+    let rendered = PaymentBlock(title: "酬金", payments: payments).render()
+
+    // 兩個不同 case → 各自的 case 名稱標題（1.2em bold）出現在 bundle 名（1.1em）之上。
+    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">甲公司</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">乙公司</b>"))
+    // bundle 名標題仍保留（多 case 不隱藏 bundle 名）。
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃1</b>"))
+    // 甲公司標題排在乙公司之前（依輸入 case 順序）。
+    let jiaIndex = try! #require(rendered.range(of: "甲公司")).lowerBound
+    let yiIndex = try! #require(rendered.range(of: "乙公司")).lowerBound
+    #expect(jiaIndex < yiIndex)
+}
+
+@Test("single case does not render a case-name heading")
+func paymentBlockOmitsCaseHeadingWhenSingleCase() {
+    // 同一 case 的兩個 bundle：不顯示 case 標題，沿用既有「多 bundle 顯示 bundle 名」行為。
+    let payments = [
+        Payment(name: "規劃1", items: [.init(names: ["A"], fee: .monthly(4000))], caseName: "甲公司"),
+        Payment(name: "規劃2", items: [.init(names: ["B"], fee: .yearly(50000))], caseName: "甲公司"),
+    ]
+    let rendered = PaymentBlock(title: "酬金", payments: payments).render()
+
+    #expect(!rendered.contains("font-size: 1.2em;"), "單一 case 不應出現 case 名稱標題")
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃1</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃2</b>"))
 }
 
 


### PR DESCRIPTION
Payment / Payment.Model 新增 caseName；新增 PaymentCaseGrouping 依 caseName 連續分組。 PaymentBlock / ReplyFormPaymentBlock 在 ≥2 個不同 case 時，於每個 case 第一個 bundle 上方 渲染 case 名稱標題（1.2em bold），bundle 名標題（1.1em）落在其下；單一 case 不渲染 case 標題， 沿用既有單/多 bundle 行為。是否顯示為 presentation 判斷，集中在本 lib，caller 只忠實提供 caseName。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持按案例分组显示付款信息，当存在多个案例时，会在相应分组上方显示案例标题，便于用户快速识别和组织付款数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->