### PR TITLE
[ADJUST] 單一 bundle 的 case 不顯示 bundle 名（per-case，含合併顯示）

### DIFF
--- a/Sources/QuotationHTML/PaymentBlock.swift
+++ b/Sources/QuotationHTML/PaymentBlock.swift
@@ -43,13 +43,15 @@ public struct PaymentBlock: Component {
 
     public init(title: String, payments: [Payment]) {
         self.title = title
-        // 「單 bundle 不顯示 bundle 名」規則 per-case 套用：每個 case 只有 1 個 bundle 時隱藏 bundle 名
+        // 「單 bundle 不顯示 bundle 名」規則 per-case 套用：每個 case **總共**只有 1 個 bundle 時隱藏 bundle 名
         // （該 case 的 case 標題已足夠識別），兩種情境一致：
         // - 多 case（合併顯示）：各 case 名標題照渲染；其中只有 1 個 bundle 的 case 隱藏其 bundle 名，
         //   只有 ≥2 bundle 的 case 才逐一顯示 bundle 名。
         // - 單一 case（分開顯示 / case 名標題不渲染）：單 bundle 同樣隱藏 bundle 名。
-        self.payments = PaymentCaseGrouping.runs(payments).flatMap { run in
-            run.payments.count == 1 ? run.payments.map { $0.hideName() } : run.payments
+        // 用「per-caseName 總數」而非連續 run 數，避免同 case bundle 在輸入中非連續時被誤判為各自單 bundle。
+        let bundleCountByCase = Dictionary(grouping: payments, by: \.caseName).mapValues(\.count)
+        self.payments = payments.map { payment in
+            (bundleCountByCase[payment.caseName] ?? 0) == 1 ? payment.hideName() : payment
         }
     }
     

--- a/Sources/QuotationHTML/PaymentBlock.swift
+++ b/Sources/QuotationHTML/PaymentBlock.swift
@@ -43,16 +43,13 @@ public struct PaymentBlock: Component {
 
     public init(title: String, payments: [Payment]) {
         self.title = title
-        // 單一 case 時沿用「單 bundle 不顯示 bundle 名」；多 case 時各 bundle 名都要顯示在 case 名底下，
-        // 故不套用單 bundle 隱藏（body 依 caseName 分組決定是否加 case 標題）。
-        self.payments = if PaymentCaseGrouping.showsCaseNames(payments) {
-            payments
-        } else if payments.count == 1 {
-            payments.map{
-                $0.hideName()
-            }
-        }else{
-            payments
+        // 「單 bundle 不顯示 bundle 名」規則 per-case 套用：每個 case 只有 1 個 bundle 時隱藏 bundle 名
+        // （該 case 的 case 標題已足夠識別），兩種情境一致：
+        // - 多 case（合併顯示）：各 case 名標題照渲染；其中只有 1 個 bundle 的 case 隱藏其 bundle 名，
+        //   只有 ≥2 bundle 的 case 才逐一顯示 bundle 名。
+        // - 單一 case（分開顯示 / case 名標題不渲染）：單 bundle 同樣隱藏 bundle 名。
+        self.payments = PaymentCaseGrouping.runs(payments).flatMap { run in
+            run.payments.count == 1 ? run.payments.map { $0.hideName() } : run.payments
         }
     }
     

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -205,6 +205,23 @@ func paymentBlockRendersCaseHeadingsWhenMultipleCases() {
     #expect(jiaIndex < yiIndex)
 }
 
+@Test("bundle-name hiding counts total bundles per case, not consecutive runs (order-independent)")
+func paymentBlockCountsBundlesPerCaseRegardlessOfOrder() {
+    // 甲公司的兩個 bundle 在輸入中被乙公司隔開（非連續）→ 仍應視為「甲有 2 bundle」而顯示其 bundle 名。
+    let payments = [
+        Payment(name: "規劃1", items: [.init(names: ["稅務帳務處理作業"], fee: .monthly(4000))], caseName: "甲公司"),
+        Payment(name: "乙方案", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(50000))], caseName: "乙公司"),
+        Payment(name: "規劃2", items: [.init(names: ["記帳作業"], fee: .monthly(3000))], caseName: "甲公司"),
+    ]
+    let rendered = PaymentBlock(title: "酬金", payments: payments).render()
+
+    // 甲公司總共 2 個 bundle → bundle 名照顯示（不因被乙公司隔開而誤隱藏）。
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃1</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃2</b>"))
+    // 乙公司只有 1 個 bundle → 隱藏。
+    #expect(!rendered.contains("乙方案"), "單一 bundle 的 case 不應顯示 bundle 名")
+}
+
 @Test("single-bundle case hides bundle name even in merged (multi-case) view")
 func paymentBlockHidesSingleBundleNamePerCaseInMergedView() {
     // 兩個 case 各只有 1 個 bundle → case 標題照渲染、但兩個 bundle 名都隱藏。

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -180,23 +180,44 @@ func createPaymentBlocHtml(payments: [Payment], result: String){
     #expect(paymentBlock.render() == result)
 }
 
-@Test("multiple cases render a case-name heading above each case's bundles")
+@Test("multiple cases render a case-name heading; bundle name shown only for cases with ≥2 bundles")
 func paymentBlockRendersCaseHeadingsWhenMultipleCases() {
     let payments = [
+        // 甲公司：2 個 bundle → bundle 名照顯示
         Payment(name: "規劃1", items: [.init(names: ["稅務帳務處理作業"], fee: .monthly(4000))], caseName: "甲公司"),
-        Payment(name: "規劃1", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(50000))], caseName: "乙公司"),
+        Payment(name: "規劃2", items: [.init(names: ["記帳作業"], fee: .monthly(3000))], caseName: "甲公司"),
+        // 乙公司：1 個 bundle → bundle 名隱藏（case 標題已足夠）
+        Payment(name: "乙方案", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(50000))], caseName: "乙公司"),
     ]
     let rendered = PaymentBlock(title: "酬金", payments: payments).render()
 
-    // 兩個不同 case → 各自的 case 名稱標題（1.2em bold）出現在 bundle 名（1.1em）之上。
+    // 兩個不同 case → 各自的 case 名稱標題（1.2em bold）。
     #expect(rendered.contains("<b style=\"font-size: 1.2em;\">甲公司</b>"))
     #expect(rendered.contains("<b style=\"font-size: 1.2em;\">乙公司</b>"))
-    // bundle 名標題仍保留（多 case 不隱藏 bundle 名）。
+    // 甲公司有 ≥2 個 bundle → bundle 名（1.1em）照顯示。
     #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃1</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃2</b>"))
+    // 乙公司只有 1 個 bundle → bundle 名隱藏（即使在合併顯示多 case 情境）。
+    #expect(!rendered.contains("乙方案"), "單一 bundle 的 case 不應顯示 bundle 名")
     // 甲公司標題排在乙公司之前（依輸入 case 順序）。
     let jiaIndex = try! #require(rendered.range(of: "甲公司")).lowerBound
     let yiIndex = try! #require(rendered.range(of: "乙公司")).lowerBound
     #expect(jiaIndex < yiIndex)
+}
+
+@Test("single-bundle case hides bundle name even in merged (multi-case) view")
+func paymentBlockHidesSingleBundleNamePerCaseInMergedView() {
+    // 兩個 case 各只有 1 個 bundle → case 標題照渲染、但兩個 bundle 名都隱藏。
+    let payments = [
+        Payment(name: "甲方案", items: [.init(names: ["稅務帳務處理作業"], fee: .monthly(4000))], caseName: "甲公司"),
+        Payment(name: "乙方案", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(50000))], caseName: "乙公司"),
+    ]
+    let rendered = PaymentBlock(title: "酬金", payments: payments).render()
+
+    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">甲公司</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">乙公司</b>"))
+    #expect(!rendered.contains("甲方案"), "單一 bundle 的 case 不應顯示 bundle 名")
+    #expect(!rendered.contains("乙方案"), "單一 bundle 的 case 不應顯示 bundle 名")
 }
 
 @Test("single case does not render a case-name heading")


### PR DESCRIPTION
## 概要
`PaymentBlock.init` 原本只在「單一 case」時對單 bundle `hideName()`；多 case（合併顯示）時保留所有 bundle 名 → 只有 1 個 bundle 的 case 在 case 標題下又多顯示一個 bundle 名（視覺重複）。

改為 **per-case 套用**「單 bundle 不顯示 bundle 名」：
```swift
self.payments = PaymentCaseGrouping.runs(payments).flatMap { run in
    run.payments.count == 1 ? run.payments.map { $0.hideName() } : run.payments
}
```

## 行為
- **多 case（合併顯示）**：case 標題照渲染；只有 1 個 bundle 的 case → 隱藏 bundle 名，≥2 bundle 的 case 才逐一顯示。
- **單一 case（分開顯示）**：單 bundle 隱藏 bundle 名（**行為不變**）。

## 測試
- 改寫 `paymentBlockRendersCaseHeadingsWhenMultipleCases`：甲公司 2 bundle（顯示名）+ 乙公司 1 bundle（隱藏名），同時覆蓋兩個分支。
- 新增 `paymentBlockHidesSingleBundleNamePerCaseInMergedView`：兩個單 bundle case 在合併顯示下都隱藏 bundle 名。
- 單一 case 既有測試不變。全套 **22 tests 全綠**。

## 下游
合併後發新 tag，consumer（OpportunityContext 等）bump pin 即生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了支付方案名称的显示规则，当分类中仅包含单个方案时将隐藏其名称，多方案情况下则正常显示。

* **Tests**
  * 更新和扩充了支付相关渲染测试，新增验证不同分类场景下的方案名称显示逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->