### PR TITLE
[FIX] 報價長字串斷行，避免金額跑版

### DIFF
--- a/Sources/HandoverDocumentHTML/Stylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Stylesheet.swift
@@ -54,7 +54,8 @@ enum Stylesheet {
     .handover .bundle { width: 100%; display: flex; flex-direction: column; gap: 8px; }
     .handover .bundle .bundleName p { font-size: 12pt; font-weight: 600; }
     .handover table.unit { width: 100%; border-collapse: collapse; break-inside: avoid-page; }
-    .handover .unit .services { vertical-align: top; }
+    /* 服務名/設定可能很長（甚至無斷點的英文）；強制可斷行，避免撐爆欄寬把金額擠到重疊 */
+    .handover .unit .services { vertical-align: top; word-break: break-all; overflow-wrap: anywhere; }
     .handover .unit .service { margin-bottom: 6px; }
     .handover .unit .serviceName { padding: 0; }
     .handover .unit .serviceName p { font-size: 12pt; font-weight: 600; }
@@ -70,7 +71,7 @@ enum Stylesheet {
     .handover .additionalService { display: flex; flex-direction: column; gap: 4px; padding: 4px 8px; width: 100%; }
     .handover .additionalService .title p { font-size: 11pt; color: #939393; }
     .handover .additionalService table.unit { width: 100%; border-collapse: collapse; }
-    .handover .additionalService .nameCell { vertical-align: top; }
+    .handover .additionalService .nameCell { vertical-align: top; word-break: break-all; overflow-wrap: anywhere; }
     .handover .additionalService .name p { font-size: 11pt; }
     .handover .additionalService .price { text-align: right; white-space: nowrap; width: 1%; vertical-align: top; padding-left: 16px; padding-right: 4px; }
     .handover .additionalService .price .dollar { font-size: 12pt; font-weight: 500; }


### PR DESCRIPTION
## 問題
訪談紀錄表（新版雙欄）報價區塊，遇到**無斷點的長字串**（例如未轉中文的英文代號 `taxComplianceAuditAndUndistributedEarningsAudit`、`profitseekingEnterpriseIncomeTaxFilingMethod`）時，服務欄會被撐到超過表格寬度，把右側金額欄（`width:1%; nowrap`）擠到與服務文字重疊（金額跑版）。

## 原因
報價 `table.unit` 為 auto layout，服務欄（`.unit .services`）未設斷字規則；Latin 長字無法自動斷行 → 該欄 min-content 超寬 → 溢出擠壞金額欄。

## 修法
服務名/設定（`.unit .services`）與附加服務名稱（`.additionalService .nameCell`）加上
`word-break: break-all; overflow-wrap: anywhere;`，任何長字串都能斷行收進欄內，金額欄即守住位置。

- 純 CSS，不改結構/邏輯。
- 中文名稱本就會斷行，視覺無變化；此修正是對「異常長字串」的健壯性保護。
- classic 版的值欄原本已有 `word-break: break-all`，本次補的是新版雙欄。

## 驗證
以超長英文代號資料測試：修正前金額與服務文字重疊；修正後長字自動斷行、金額靠右對齊不跑版。44 個單元測試通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化手册/交接文档中的长服务名称与额外服务名称换行表现，避免文字过长时挤压版面或发生重叠。
  * 提升页面在包含无空格长字符串时的排版稳定性，使内容更容易完整阅读。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->