### PR TITLE
[ADD] classic 報價 QuotingGroup：組合項目/服務項目 + 每項金額 + 總價欄

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage2.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage2.swift
@@ -71,24 +71,26 @@ public struct ClassicFormPage2: Component {
         }
     }
 
-    /// 一個 Row 對應的 table row 內容（不含最左區塊標籤）。多數 1 列；.service 含設定時 2 列。
+    // 表格邏輯共 5 欄：① 區塊直書標籤 ② 群組/欄位標籤 ③ 內容（服務名/設定/值）④ 每項金額 ⑤ 總價。
+    // 非報價列以 colspan 填滿 ③④⑤（或 ②③④⑤），讓各區塊與報價的欄界對齊。
+    /// 一個 Row 對應的 table row 內容（不含最左區塊標籤①）。.quoting 會展開成多列。
     private func cellGroups(for row: Row) -> [Component] {
         switch row.kind {
         case .field:
             return [ComponentGroup {
                 TableCell(Text(row.label ?? "")).class("fieldLabel")
-                multilineCell(row.value).class("fieldValue")
+                multilineCell(row.value).class("fieldValue").attribute(named: "colspan", value: "3")
             }]
         case .markdown:
             // 值為 markdown 原文，渲染成 HTML 後注入（標題/清單/粗體/inline <span> 等）。
             return [ComponentGroup {
                 TableCell(Text(row.label ?? "")).class("fieldLabel")
-                TableCell(Div(html: MarkdownHTML.render(row.value))).class("fieldValue")
+                TableCell(Div(html: MarkdownHTML.render(row.value))).class("fieldValue").attribute(named: "colspan", value: "3")
             }]
         case .heading:
-            return [TableCell(Text(row.value)).class("fieldValue rowHeading").attribute(named: "colspan", value: "2")]
+            return [TableCell(Text(row.value)).class("fieldValue rowHeading").attribute(named: "colspan", value: "4")]
         case .full:
-            return [multilineCell(row.value).class("fieldValue").attribute(named: "colspan", value: "2")]
+            return [multilineCell(row.value).class("fieldValue").attribute(named: "colspan", value: "4")]
         case .pairs:
             // 一列多組 label｜value 內嵌於單一跨欄格（避免增生表格欄、壓縮其他列的值欄）
             return [TableCell {
@@ -96,24 +98,40 @@ public struct ClassicFormPage2: Component {
                     Span(pair.0).class("pairLabel")
                     Span(pair.1).class("pairValue")
                 }
-            }.class("fieldValue").attribute(named: "colspan", value: "2")]
-        case .service:
-            // 服務名(+公費)為主列；設定條列於其下，「服務項目」標籤 rowspan 跨兩列、設定只佔值欄。
-            let label = row.label ?? "服務項目"
-            if row.detail.isEmpty {
-                return [ComponentGroup {
-                    TableCell(Text(label)).class("fieldLabel")
-                    multilineCell(row.value).class("fieldValue")
-                }]
-            }
-            return [
-                ComponentGroup {
-                    TableCell(Text(label)).class("fieldLabel").attribute(named: "rowspan", value: "2")
-                    multilineCell(row.value).class("fieldValue")
-                },
-                multilineCell(row.detail).class("fieldValue")
-            ]
+            }.class("fieldValue").attribute(named: "colspan", value: "4")]
+        case .quoting:
+            return quotingCellGroups(row.quoting)
         }
+    }
+
+    /// 報價群組（組合項目／服務項目）：
+    /// ② 群組標籤、⑤ 總價皆 rowspan 跨整組；每個服務的「服務名(+每項金額④)」為主列，
+    /// 設定條列於其下、跨 ③④。有每項金額時服務名佔③、金額佔④；無則服務名跨 ③④。
+    private func quotingCellGroups(_ group: QuotingGroup?) -> [Component] {
+        guard let group else { return [] }
+        let rowCount = group.services.reduce(0) { $0 + 1 + ($1.configs.isEmpty ? 0 : 1) }
+        var out: [Component] = []
+        for (index, svc) in group.services.enumerated() {
+            let isFirst = index == 0
+            out.append(ComponentGroup {
+                if isFirst {
+                    TableCell(Text(group.label)).class("fieldLabel").attribute(named: "rowspan", value: "\(rowCount)")
+                }
+                if let amount = svc.amount, !amount.isEmpty {
+                    multilineCell(svc.name).class("serviceName")
+                    TableCell(Text(amount)).class("serviceAmount")
+                } else {
+                    multilineCell(svc.name).class("serviceName").attribute(named: "colspan", value: "2")
+                }
+                if isFirst {
+                    multilineCell(group.total).class("serviceTotal").attribute(named: "rowspan", value: "\(rowCount)")
+                }
+            })
+            if !svc.configs.isEmpty {
+                out.append(multilineCell(svc.configs).class("serviceConfig").attribute(named: "colspan", value: "2"))
+            }
+        }
+        return out
     }
 
     /// 值可含 \n，逐行以 <br> 斷開。
@@ -142,37 +160,65 @@ extension ClassicFormPage2 {
     }
 
     public struct Row {
-        enum Kind { case field, markdown, heading, full, pairs, service }
+        enum Kind { case field, markdown, heading, full, pairs, quoting }
         let kind: Kind
         let label: String?
         let value: String
-        let detail: String
         let pairs: [(String, String)]
+        let quoting: QuotingGroup?
 
         /// label｜value 一般欄位
         public static func field(_ label: String, _ value: String) -> Row {
-            Row(kind: .field, label: label, value: value, detail: "", pairs: [])
+            Row(kind: .field, label: label, value: value, pairs: [], quoting: nil)
         }
         /// label｜value，value 以 markdown 渲染（訪談紀錄等富文字欄位）
         public static func markdown(_ label: String, _ value: String) -> Row {
-            Row(kind: .markdown, label: label, value: value, detail: "", pairs: [])
+            Row(kind: .markdown, label: label, value: value, pairs: [], quoting: nil)
         }
         /// 粗體跨欄小標（如報價的 bundle 名）
         public static func heading(_ text: String) -> Row {
-            Row(kind: .heading, label: nil, value: text, detail: "", pairs: [])
+            Row(kind: .heading, label: nil, value: text, pairs: [], quoting: nil)
         }
         /// 跨欄整段文字
         public static func full(_ value: String) -> Row {
-            Row(kind: .full, label: nil, value: value, detail: "", pairs: [])
+            Row(kind: .full, label: nil, value: value, pairs: [], quoting: nil)
         }
         /// 一列多組 label｜value
         public static func pairs(_ pairs: [(String, String)]) -> Row {
-            Row(kind: .pairs, label: nil, value: "", detail: "", pairs: pairs)
+            Row(kind: .pairs, label: nil, value: "", pairs: pairs, quoting: nil)
         }
-        /// 報價服務項目：服務名(+公費)為主列；configs（設定，可含 \n 條列）顯示於其下，
-        /// 「服務項目」標籤 rowspan 跨兩列、設定只佔值欄。configs 空字串則只有一列。
-        public static func service(name: String, configs: String) -> Row {
-            Row(kind: .service, label: "服務項目", value: name, detail: configs, pairs: [])
+        /// 報價群組：label＝「組合項目」(多項) 或「服務項目」(單項)；total＝最右側總價（rowspan 跨整組）。
+        public static func quoting(_ group: QuotingGroup) -> Row {
+            Row(kind: .quoting, label: nil, value: "", pairs: [], quoting: group)
+        }
+    }
+
+    /// 報價群組：一筆共用報價（pricingDetail）。多服務＝組合項目、單服務＝服務項目。
+    public struct QuotingGroup {
+        /// 群組標籤：「組合項目」/「服務項目」
+        public let label: String
+        /// 最右側總價（本組報價金額），可含 \n，e.g. "$279,000 元 / 年"
+        public let total: String
+        public let services: [QuotingService]
+        public init(label: String, total: String, services: [QuotingService]) {
+            self.label = label
+            self.total = total
+            self.services = services
+        }
+    }
+
+    /// 報價群組內的單一服務。
+    public struct QuotingService {
+        /// 服務名（如「財務簽證」）
+        public let name: String
+        /// 每項金額（組合項目拆分用，第④欄）。nil／空字串則服務名跨 ③④、不顯示金額欄。
+        public let amount: String?
+        /// 設定條列（含「- 」前綴，可 \n 多行），顯示於服務名下方、跨 ③④。空字串則無設定列。
+        public let configs: String
+        public init(name: String, amount: String? = nil, configs: String = "") {
+            self.name = name
+            self.amount = amount
+            self.configs = configs
         }
     }
 }

--- a/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
@@ -33,7 +33,8 @@ enum ClassicStylesheet {
     .classic table.classicForm, .classic table.classicForm2 { width: 100%; border-collapse: collapse; }
     .classic table.classicForm { table-layout: fixed; }
     .classic table.classicForm2 { table-layout: auto; margin-top: 4px; }
-    .classic .sectionLabel, .classic .fieldLabel, .classic .fieldValue, .classic .blockCell { border: 1px solid #000; }
+    .classic .sectionLabel, .classic .fieldLabel, .classic .fieldValue, .classic .blockCell,
+    .classic .serviceName, .classic .serviceAmount, .classic .serviceTotal, .classic .serviceConfig { border: 1px solid #000; }
 
     /* 區塊直書標籤（逐字斷行堆疊，不用 writing-mode，避免末字被裁） */
     /* 非粗體：粗體楷體（特粗楷體）缺「訊/錄」等字形會變空白，故區塊標籤不加粗 */
@@ -48,6 +49,10 @@ enum ClassicStylesheet {
     /* 第 2 頁：label 欄固定窄寬、長標籤換行（避免整欄被「代辦年度CTP申報」撐寬） */
     .classic .classicForm2 .fieldLabel { width: 110px; white-space: normal; word-break: normal; }
     .classic .classicForm2 .rowHeading { background: #fafafa; font-weight: 700; }
+    /* 報價群組：服務名 / 每項金額(右) / 設定 / 總價(置中、跨整組) */
+    .classic .serviceName, .classic .serviceConfig { word-break: break-all; padding: 3px 8px; font-size: 1.08rem; vertical-align: top; }
+    .classic .serviceAmount { white-space: nowrap; text-align: right; padding: 3px 8px; font-size: 1.08rem; vertical-align: top; }
+    .classic .serviceTotal { text-align: center; padding: 3px 8px; font-size: 1.08rem; vertical-align: middle; word-break: keep-all; }
     /* 一列多組 label｜value（扣繳人數／分支機構家數；各式發票張數） */
     .classic .pairLabel { color: #555; margin-right: 6px; }
     .classic .pairValue { font-weight: 600; margin-right: 22px; }

--- a/Sources/Main/main.swift
+++ b/Sources/Main/main.swift
@@ -352,10 +352,15 @@ let classic = ClassicHandoverDocument(
     page1: classicPage1,
     page2Sections: [
         .init(label: "報價", rows: [
-            .heading("▼ 財務會計委外作業"),
-            // 服務項目（rowspan）｜服務名+公費；設定以 - 條列於其下、只佔值欄
-            .service(name: "記帳服務 $5,000 元 / 月 ( 14 個月 )", configs: "- 開始月份 115 年 5 月\n- 預估年營收 1,000 萬元"),
-            .service(name: "營所稅查核簽證 $30,000 元 / 年", configs: "- 年度 115 年度")
+            // 組合項目（多服務共用一價）：每項可顯示金額（④欄），總價在最右（⑤欄、跨整組）
+            .quoting(.init(label: "組合項目", total: "$279,000\n元 / 年", services: [
+                .init(name: "財務簽證", amount: "$279,000", configs: "- 開始服務時間 115年1月"),
+                .init(name: "稅務簽證（含未分配盈餘）", amount: "$279,000", configs: "- 開始服務時間 115年1月")
+            ])),
+            // 服務項目（單服務）：服務名跨 ③④，總價在最右
+            .quoting(.init(label: "服務項目", total: "$7,000 元 /\n月\n( 14 個月 )", services: [
+                .init(name: "稅務帳", configs: "- 開始服務時間 115年7月\n- 申報類型 按期申報\n- 申報方式 稅務簽證")
+            ]))
         ]),
         .init(label: "附加服務", rows: [
             .full("代辦年度 CTP 申報 $2,000 元 / 年")


### PR DESCRIPTION
## 概述
classic 補充頁「報價」改用結構化的 `QuotingGroup`，建立組合項目 / 服務項目 + 每項金額 + 總價欄的框架。

## 架構
- `ClassicFormPage2.Row` 以 `.quoting(QuotingGroup)` 取代 `.service`。
- `QuotingGroup`：`label`（「組合項目」多服務 /「服務項目」單服務）、`total`（最右側總價，rowspan 跨整組）、`services`。
- `QuotingService`：`name`、`amount`（每項金額 ④欄，組合拆分用，可 nil）、`configs`（設定條列）。
- 渲染：
  - 群組 label（②）、總價（⑤）皆 rowspan 跨整組。
  - 服務有 `amount` → 服務名佔③、金額佔④；無 → 服務名跨 ③④。
  - 設定條列於服務名下、跨 ③④。
  - 表格改 5 欄邏輯，其餘 row kind（field/markdown/heading/full/pairs）以 colspan 填滿對齊。

> **金額拆分為未來功能**：PDFGenerator 只負責架構（支援每項 `amount`）；實際金額由 HandoverDocumentViewContext 帶入。不論組合/服務項目，最右側總價都是該組報價金額。

## 驗證
- `swift build`、`swift test` 46 tests 全過；WeasyPrint 產出 classic page2 符合 mockup。

## 下游（ViewContext）
- `classicQuotingRows` 由 `.service` 改用 `.quoting`（需本 PR 新 tag）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 报价页支持更清晰的分组展示，能同时呈现服务名称、单项金额、设置内容与总价。
  * 表格版式已优化，跨栏信息与分组标题的显示更一致，阅读体验更顺畅。

* **界面优化**
  * 调整了经典版样式，强化报价相关栏位的边框、对齐与换行规则。
  * 示例内容已更新为结构化报价区块，展示更完整的报价信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->