### PR TITLE
[FIX] classic 報價金額/總價欄過寬（width:1% 收縮）

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
@@ -51,8 +51,9 @@ enum ClassicStylesheet {
     .classic .classicForm2 .rowHeading { background: #fafafa; font-weight: 700; }
     /* 報價群組：服務名 / 每項金額(右) / 設定 / 總價(置中、跨整組) */
     .classic .serviceName, .classic .serviceConfig { word-break: break-all; padding: 3px 8px; font-size: 1.08rem; vertical-align: top; }
-    .classic .serviceAmount { white-space: nowrap; text-align: right; padding: 3px 8px; font-size: 1.08rem; vertical-align: top; }
-    .classic .serviceTotal { text-align: center; padding: 3px 8px; font-size: 1.08rem; vertical-align: middle; word-break: keep-all; }
+    /* width:1% → 收縮到內容寬，不分配多餘表寬（否則 auto-layout 會把右側欄撐寬） */
+    .classic .serviceAmount { white-space: nowrap; text-align: right; padding: 3px 8px; font-size: 1.08rem; vertical-align: top; width: 1%; }
+    .classic .serviceTotal { text-align: center; padding: 3px 8px; font-size: 1.08rem; vertical-align: middle; word-break: keep-all; width: 1%; }
     /* 一列多組 label｜value（扣繳人數／分支機構家數；各式發票張數） */
     .classic .pairLabel { color: #555; margin-right: 6px; }
     .classic .pairValue { font-weight: 600; margin-right: 22px; }


### PR DESCRIPTION
## 問題
classic 報價的「每項金額」「總價」欄過寬。根因不是文字長度（斷行無效）——`table-layout: auto` 會把表格剩餘寬度分配給**未約束寬度**的欄，這兩欄因此被撐寬。

## 修正
`.serviceAmount` / `.serviceTotal` 加 `width: 1%`，讓欄收縮到內容寬度，剩餘寬度留給服務名欄。

## 驗證
WeasyPrint 實際產出：金額/總價欄收窄、服務名欄變寬，符合預期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 调整了报价相关栏位的显示宽度，使金额与总计列更紧凑，页面表格展示更稳定、整洁。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->