### PR TITLE
[FIX] classic PDF 顯示：連結重疊（WeasyPrint 相容）+ 第1頁客戶狀況換行

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
@@ -96,9 +96,25 @@ public struct ClassicFormPage1: Component {
         Div {
             Paragraph("1. 前所服務業務：\(model.previousFirmServices ?? "")")
             Paragraph("2. 前所資訊及更換原因：\(model.previousFirmChangeReason ?? "")")
-            Paragraph("3. 客戶狀況及注意事項：\(model.clientNotesSummary ?? "")")
+            // 客戶狀況摘要可含 \n（多段落接起），逐行以 <br> 斷開。
+            clientNotesParagraph
             Paragraph("關係企業：\(model.relatedBusinessSummary ?? "")")
         }.class("interviewBlock")
+    }
+
+    /// 「3. 客戶狀況及注意事項」：值可含 \n（多段落），逐行以 <br> 斷開。
+    private var clientNotesParagraph: Component {
+        let lines = (model.clientNotesSummary ?? "").split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        return Paragraph {
+            Text("3. 客戶狀況及注意事項：")
+            for (index, line) in lines.enumerated() {
+                if index < lines.count - 1 {
+                    Text(line).addLineBreak()
+                } else {
+                    Text(line)
+                }
+            }
+        }
     }
 
     // MARK: 服務（由報價推導勾選）

--- a/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
@@ -21,12 +21,16 @@ enum ClassicStylesheet {
     /* 標題用一般字重：粗體楷體（特粗楷體）缺「錄/訊」等字形會變空白，故不加粗 */
     .classic .formTitle { font-size: 1.7rem; font-weight: normal; margin: 0; letter-spacing: 6px; }
     .classic .titleRow2 .formTitle { flex: 0 0 auto; align-self: center; }
-    .classic .classicTopRight { flex: 1 1 0; display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
-    .classic .shareUrlContainer { display: flex; gap: 6px; }
-    .classic .shareUrlContainer .url { display: flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: 4px; background: #3A9CCD; white-space: nowrap; }
-    .classic .shareUrlContainer .url a { color: #F1F3F5; font-size: 0.8rem; text-decoration: none; white-space: nowrap; }
-    .classic .shareUrlContainer .urlIcon { display: flex; align-items: center; }
-    .classic .shareUrlContainer .urlIcon svg { display: block; }
+    /* 不用巢狀 flex / gap：舊版 WeasyPrint 的 flexbox（尤其 gap、flex-direction:column）
+       會把兩個連結按鈕疊在一起。改用 inline-block + margin + text-align，跨 WeasyPrint 版本一致。
+       (flex: 1 1 0 僅為 titleRow2 內的 flex-item 佔寬用，與本區塊內部排版無關) */
+    .classic .classicTopRight { flex: 1 1 0; text-align: right; }
+    .classic .shareUrlContainer { margin-bottom: 4px; white-space: nowrap; }
+    .classic .shareUrlContainer .url { display: inline-block; margin-left: 6px; padding: 3px 10px; border-radius: 4px; background: #3A9CCD; white-space: nowrap; }
+    .classic .shareUrlContainer .url:first-child { margin-left: 0; }
+    .classic .shareUrlContainer .url a { color: #F1F3F5; font-size: 0.8rem; text-decoration: none; white-space: nowrap; vertical-align: middle; }
+    .classic .shareUrlContainer .urlIcon { display: inline-block; vertical-align: middle; margin-right: 4px; }
+    .classic .shareUrlContainer .urlIcon svg { display: inline-block; vertical-align: middle; }
     .classic .qrImage svg { display: block; width: 58px; height: 58px; }
 
     /* ===== 主表（單一扁平表格，框線統一 1px） ===== */

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -353,3 +353,12 @@ import Foundation
     #expect(headerHTML.contains("header_logo"))
     #expect(headerHTML.contains("position: fixed"))
 }
+
+@Test func classicPage1ClientNotesRendersLineBreaks() {
+    // 客戶狀況摘要含 \n（多段落接起）→ 第 1 頁應以 <br> 斷行
+    let doc = ClassicHandoverDocument(page1: .init(companyName: "範例股份有限公司", clientNotesSummary: "第一段\n第二段"))
+    let html = doc.render()
+    #expect(html.contains("第一段"))
+    #expect(html.contains("第二段"))
+    #expect(html.contains("<br"))
+}


### PR DESCRIPTION
classic 訪談紀錄表兩處顯示修正（將於同一版本釋出）。

## 1) 第 2 頁外/內網連結重疊
`.shareUrlContainer` / `.classicTopRight` 用巢狀 flexbox（含 `gap`、`flex-direction:column`）,
較舊版 WeasyPrint flexbox 實作不完整會把兩顆連結按鈕疊在一起。改用 `inline-block` + `margin`
+ `text-align` + `white-space:nowrap`,跨 WeasyPrint 版本一致（本機 65.1 實測：並排、QR 在下、無重疊）。

## 2) 第 1 頁「客戶狀況及注意事項」換行
該摘要值可含 `\n`（呼叫端把多段落接起）。比照第 2 頁 `multilineCell`,逐行以 `<br>` 斷開,
讓段落在第 1 頁正確換行。

## 測試
既有 + 新增 `classicPage1ClientNotesRendersLineBreaks`,共 47 tests 通過。

## 後續
發新版後於 HandoverDocumentViewContext bump PDFGenerator 相依版本才生效。
另建議部署環境 WeasyPrint 升級到 ≥60。

🤖 Generated with [Claude Code](https://claude.com/claude-code)