### PR TITLE
[CHANGE] classic 第1頁客戶狀況改為縮排文字區塊

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
@@ -102,18 +102,21 @@ public struct ClassicFormPage1: Component {
         }.class("interviewBlock")
     }
 
-    /// 「3. 客戶狀況及注意事項」：值可含 \n（多段落），逐行以 <br> 斷開。
+    /// 「3. 客戶狀況及注意事項」：標題獨立一行，內容以「縮排文字區塊」呈現（值可含 \n 多段落，逐行 <br>；
+    /// 區塊 padding-left 讓過長換行也維持縮排）。
     private var clientNotesParagraph: Component {
         let lines = (model.clientNotesSummary ?? "").split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        return Paragraph {
-            Text("3. 客戶狀況及注意事項：")
-            for (index, line) in lines.enumerated() {
-                if index < lines.count - 1 {
-                    Text(line).addLineBreak()
-                } else {
-                    Text(line)
+        return ComponentGroup {
+            Paragraph("3. 客戶狀況及注意事項：")
+            Div {
+                for (index, line) in lines.enumerated() {
+                    if index < lines.count - 1 {
+                        Text(line).addLineBreak()
+                    } else {
+                        Text(line)
+                    }
                 }
-            }
+            }.class("clientNotesBody")
         }
     }
 

--- a/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
@@ -68,6 +68,8 @@ enum ClassicStylesheet {
     .classic .remarkBlock { padding: 4px 8px; font-size: 1.08rem; }
     .classic .interviewBlock p,
     .classic .remarkBlock p { padding: 1px 0; }
+    /* 客戶狀況及注意事項：縮排文字區塊（左側細線 + 內縮，過長換行仍維持縮排） */
+    .classic .interviewBlock .clientNotesBody { margin: 1px 0 3px 0.4em; padding: 1px 0 1px 0.9em; border-left: 2px solid #bbb; line-height: 1.5; }
     .classic .serviceBlock { line-height: 1.85; }
     .classic .invoiceLine { padding-top: 3px; }
 

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -354,10 +354,12 @@ import Foundation
     #expect(headerHTML.contains("position: fixed"))
 }
 
-@Test func classicPage1ClientNotesRendersLineBreaks() {
-    // 客戶狀況摘要含 \n（多段落接起）→ 第 1 頁應以 <br> 斷行
+@Test func classicPage1ClientNotesRendersIndentedBlockWithLineBreaks() {
+    // 客戶狀況摘要含 \n（多段落接起）→ 第 1 頁以「縮排文字區塊」呈現、逐行 <br> 斷行
     let doc = ClassicHandoverDocument(page1: .init(companyName: "範例股份有限公司", clientNotesSummary: "第一段\n第二段"))
     let html = doc.render()
+    #expect(html.contains("客戶狀況及注意事項"))
+    #expect(html.contains("clientNotesBody"))   // 縮排文字區塊容器
     #expect(html.contains("第一段"))
     #expect(html.contains("第二段"))
     #expect(html.contains("<br"))


### PR DESCRIPTION
## 需求
第 1 頁「3. 客戶狀況及注意事項」原本標題與內容同行、換行不縮排,閱讀性差。改為標題獨立一行,內容以「縮排文字區塊」呈現。

## 作法
- `ClassicFormPage1`：標題 `3. 客戶狀況及注意事項：` 獨立一行,內容放入 `.clientNotesBody` 區塊(多段落逐行 `<br>`)。
- `ClassicStylesheet`：`.clientNotesBody` 左側細線 + `padding-left` 內縮,**過長換行也維持縮排**。

## 驗證
以 WeasyPrint 65.1 實測(含長行換行)：標題獨立行、內容縮排區塊、換行與長行皆維持縮排。
既有 + 更新的 `classicPage1ClientNotesRendersIndentedBlockWithLineBreaks`,共 47 tests 通過。

## 後續
發新版後於 HandoverDocumentViewContext bump PDFGenerator 相依版本才生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化“客户状况及注意事项”内容的版式，将正文显示为带缩进和左侧标线的独立区块。
  * 长文本现可保持更清晰的行间距与缩进效果。

* **测试**
  * 补充并强化相关内容的换行、标题及缩进区块显示验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->