### PR TITLE
[FIX] classic 第2頁 QR 右對齊

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
@@ -31,7 +31,9 @@ enum ClassicStylesheet {
     .classic .shareUrlContainer .url a { color: #F1F3F5; font-size: 0.8rem; text-decoration: none; white-space: nowrap; vertical-align: middle; }
     .classic .shareUrlContainer .urlIcon { display: inline-block; vertical-align: middle; margin-right: 4px; }
     .classic .shareUrlContainer .urlIcon svg { display: inline-block; vertical-align: middle; }
-    .classic .qrImage svg { display: block; width: 58px; height: 58px; }
+    /* inline-block（非 block）→ 受 classicTopRight 的 text-align:right 影響而右對齊，與連結按鈕右緣切齊 */
+    .classic .qrImage { display: block; text-align: right; }
+    .classic .qrImage svg { display: inline-block; width: 58px; height: 58px; }
 
     /* ===== 主表（單一扁平表格，框線統一 1px） ===== */
     .classic table.classicForm, .classic table.classicForm2 { width: 100%; border-collapse: collapse; }


### PR DESCRIPTION
## 問題
第 2 頁右上角 QR 跑版：靠左,未與「內網連結」按鈕右緣切齊。

## 根因
PR #69 把 `.classicTopRight` 由 `flex-direction:column; align-items:flex-end` 改為 `text-align:right`（為了 WeasyPrint 相容）。但 QR 的 `svg` 仍是 `display:block`,而 block 元素不受 `text-align` 影響 → QR 靠左。

## 修正
`.qrImage` 區塊 `text-align:right`,`.qrImage svg` 改 `inline-block`,讓 QR 受右對齊、與連結按鈕右緣切齊。

## 驗證
WeasyPrint 65.1 實測：外網/內網連結並排、QR 右緣與內網連結切齊。既有 47 tests 通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化经典样式下二维码区域的布局，使二维码能够正确右对齐。
  * 调整二维码显示方式，同时保持其 58×58 像素尺寸。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->