### PR TITLE
[FIX] classic 報價總價欄跑版（元/次 被斷行）

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
@@ -59,7 +59,8 @@ enum ClassicStylesheet {
     .classic .serviceName, .classic .serviceConfig { word-break: break-all; padding: 3px 8px; font-size: 1.08rem; vertical-align: top; }
     /* width:1% → 收縮到內容寬，不分配多餘表寬（否則 auto-layout 會把右側欄撐寬） */
     .classic .serviceAmount { white-space: nowrap; text-align: right; padding: 3px 8px; font-size: 1.08rem; vertical-align: top; width: 1%; }
-    .classic .serviceTotal { text-align: center; padding: 3px 8px; font-size: 1.08rem; vertical-align: middle; word-break: keep-all; width: 1%; }
+    /* nowrap：每行(金額 / 「元 / 次」…)不再自動斷開，欄寬撐到最長一行；避免「元 / 次」被空白處斷成兩行跑版 */
+    .classic .serviceTotal { text-align: center; padding: 3px 8px; font-size: 1.08rem; vertical-align: middle; white-space: nowrap; word-break: keep-all; width: 1%; }
     /* 一列多組 label｜value（扣繳人數／分支機構家數；各式發票張數） */
     .classic .pairLabel { color: #555; margin-right: 6px; }
     .classic .pairValue { font-weight: 600; margin-right: 22px; }


### PR DESCRIPTION
## 問題
第 2 頁報價的最右「總價」欄過窄,`元 / 次`、`元 / 年` 被空白處斷成兩行(如 `元 /` + `次`),跑版。

## 根因
`.serviceTotal` 有 `width:1%`(收縮到內容寬)但**沒有 `white-space:nowrap`**(不像 `.serviceAmount`)。`word-break:keep-all` 只保 CJK 不斷,但 `元 / 次` 的空白仍是斷點。

## 修正
`.serviceTotal` 補上 `white-space:nowrap`：每行(金額 / 「元 / 次」)不再自動斷開,欄寬撐到最長一行,單位維持同一行。金額與單位分行仍由字串中的 `\n`(→`<br>`)控制,不受影響。

## 驗證
WeasyPrint 65.1 實測：`$9,000 / 元 / 次`、`$18,000 / 元 / 年` 皆兩行、單位不跑版。47 tests 通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复经典样式下服务总额内容自动换行的问题。
  * 服务总额现可保持在同一行显示，提升版面一致性与可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->