### PR TITLE
[FIX] classic 第2頁分頁以 section 為單位（避免區塊標籤孤兒跑版）

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage2.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage2.swift
@@ -44,10 +44,15 @@ public struct ClassicFormPage2: Component {
                     }
                 }.class("classicTopRight")
             }.class("titleRow2")
-            // 單一扁平表格（同第 1 頁），框線統一 1px
-            Table {
+            // 單一扁平表格（同第 1 頁），框線統一 1px。每個 section 包成獨立 <tbody>，
+            // 分頁時以 section 為單位整段移動（break-inside: avoid），不會把區塊直書標籤與首列
+            // 孤兒留在上一頁。用 Element 自建 table/tbody，避開 Plot 的 Table 會把每個 child
+            // 自動包成 <tr> 的行為（會產生 <tr><tbody>）。
+            Element(name: "table") {
                 for section in sections {
-                    flatSection(section)
+                    Element(name: "tbody") {
+                        flatSection(section)
+                    }.class("sectionGroup")
                 }
             }.class("classicForm2")
         }

--- a/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicStylesheet.swift
@@ -39,6 +39,10 @@ enum ClassicStylesheet {
     .classic table.classicForm, .classic table.classicForm2 { width: 100%; border-collapse: collapse; }
     .classic table.classicForm { table-layout: fixed; }
     .classic table.classicForm2 { table-layout: auto; margin-top: 4px; }
+    /* 分頁以 section(<tbody>) 為單位整段移動，避免區塊直書標籤/首列被孤兒留在上一頁；tr 也不從中間斷開。
+       break-inside 與 page-break-inside 併列以相容不同 WeasyPrint 版本。 */
+    .classic .classicForm2 .sectionGroup { break-inside: avoid; page-break-inside: avoid; }
+    .classic .classicForm2 tr { break-inside: avoid; page-break-inside: avoid; }
     .classic .sectionLabel, .classic .fieldLabel, .classic .fieldValue, .classic .blockCell,
     .classic .serviceName, .classic .serviceAmount, .classic .serviceTotal, .classic .serviceConfig { border: 1px solid #000; }
 

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -354,6 +354,23 @@ import Foundation
     #expect(headerHTML.contains("position: fixed"))
 }
 
+@Test func classicPage2WrapsEachSectionInBreakAvoidTbody() {
+    // 每個 section 應包成獨立 <tbody class="sectionGroup">，供分頁時整段一起移動
+    let doc = ClassicHandoverDocument(
+        page1: .init(companyName: "範例股份有限公司"),
+        page2Sections: [
+            .init(label: "關係企業", rows: [.field("公司名稱", "誠信商事有限公司")]),
+            .init(label: "前手", rows: [.field("前所名稱", "捷瑞會計師事務所")]),
+        ]
+    )
+    let html = doc.render()
+    #expect(html.contains("<tbody"))
+    #expect(html.contains("sectionGroup"))
+    #expect(html.contains("break-inside: avoid"))
+    // 不應出現把 tbody 誤包進 tr 的結構
+    #expect(!html.contains("<tr><tbody"))
+}
+
 @Test func classicPage1ClientNotesRendersIndentedBlockWithLineBreaks() {
     // 客戶狀況摘要含 \n（多段落接起）→ 第 1 頁以「縮排文字區塊」呈現、逐行 <br> 斷行
     let doc = ClassicHandoverDocument(page1: .init(companyName: "範例股份有限公司", clientNotesSummary: "第一段\n第二段"))


### PR DESCRIPTION
## 問題
第 2 頁（補充資訊）分頁時會從 section 中間斷開,把區塊直書標籤與首列孤兒留在上一頁。
例：前手的「前」+「前所名稱」留在頁尾,「前所服務業務/更換原因」+「手」跑到次頁。

## 修正
每個 section 各自包成 `<tbody class="sectionGroup">`,套 `break-inside: avoid`（+`page-break-inside`）,分頁時**整段一起移到下一頁**；`tr` 也不從中間斷開。
仍維持**單一 `<table>`**（`border-collapse`）→ 框線 1px、不像巢狀 table 疊成雙線。

實作：用 Plot 的 `Element` 自建 `table`/`tbody`（Plot 的 `Table` 會把每個 child 自動包成 `<tr>`,會產生 `<tr><tbody>`）。

## 驗證
WeasyPrint 65.1 實測：長 section 於**列邊界**乾淨斷頁;小的「前手」section 整段移到次頁、標籤與各列一起,不再孤兒跑版。
新增 `classicPage2WrapsEachSectionInBreakAvoidTbody`,共 48 tests 通過。

## 備註
超過一整頁的長 section（如訪談紀錄長文）仍必然會斷,但會斷在列邊界、不會把單列從中撕開。