### PR TITLE
[CHANGE] 報價單酬金/同意函分頁與格式調整

### DIFF
--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -23,7 +23,8 @@ public struct Payment: Component {
     /// `nil` 或空字串 → 不渲染此 row。
     ///
     /// **渲染重點**：
-    /// - 補充說明 row 兩個 cell 帶 `border-top: 1px solid black` → 上方一條跨整欄分隔線（取代舊 `*` marker）。
+    /// - 補充說明 row 為跨整欄（colspan=3）cell，內文以 `*` 標記開頭（marker 由 renderer 以 scoped
+    ///   `::before` inject 到行首，與內文同一行）；不再畫上方橫線。
     /// - markdown / 樣式細節見 `SupplementaryNoteHTMLRenderer`。
     public let supplementaryNote: String?
 
@@ -32,27 +33,24 @@ public struct Payment: Component {
             if needShowName {
                 TableRow{
                     TableCell{
-                        Text(name).bold().style("font-size: 1.1em;")
+                        Text(name).bold().style("font-size: 0.95em;")
                     }.attribute(named: "colspan", value: "3")
                 }
             }
             for (index, item) in items.enumerated(){
                 TableRow{
-                    TableCell("(\(index+1))").style("vertical-align: top; width: 1.35rem;")
+                    TableCell("\(index+1).").style("vertical-align: top; width: 1.35rem;")
                     item
                 }.style("padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;")
             }
             if let supplementaryNote, !supplementaryNote.isEmpty {
-                // 補充說明上方一條橫線：border 下在 **cell** 而非 row —— border-collapse 下 weasyprint
-                // 對非首列的 row-level border-top 不穩（會與前一列 border 塌掉而不畫），cell border 才可靠。
-                // 兩個 cell（占位 + colspan=2）都加 → 跨整欄、視覺等同 PaymentBlock 表頭分隔線。
+                // 補充說明以 `*` 標記開頭（不再畫上方橫線）：marker 由 renderer 以 scoped `::before` inject
+                // 到內文行首，故與內文同一行、且不污染 caller 的 markdown。整段跨欄（colspan=3）從左緣起排。
                 // markdown → HTML 在此渲染（presentation 歸 PDFGenerator）；caller 傳的是 markdown。
                 TableRow{
-                    TableCell()  // alignment 占位，對齊 (n) 編號欄
-                        .style("border-top: 1px solid black;")
-                    TableCell(html: SupplementaryNoteHTMLRenderer.render(markdown: supplementaryNote))
-                        .attribute(named: "colspan", value: "2")
-                        .style("border-top: 1px solid black; padding-top: 0.5em;")
+                    TableCell(html: SupplementaryNoteHTMLRenderer.render(markdown: supplementaryNote, marker: "*"))
+                        .attribute(named: "colspan", value: "3")
+                        .style("padding-top: 0.5em;")
                 }
             }
         }

--- a/Sources/QuotationHTML/PaymentBlock.swift
+++ b/Sources/QuotationHTML/PaymentBlock.swift
@@ -16,28 +16,31 @@ public struct PaymentBlock: Component {
         let showCaseNames = PaymentCaseGrouping.showsCaseNames(payments)
         return ComponentGroup{
             Paragraph(title).style("font-size: 1.1rem;")
-            Table{
-                TableRow{
-                    TableCell("服務項目").attribute(named: "colspan", value: "2").style("text-align: center ;")
-                    TableCell{
-                        Div("公費金額").style("white-space: nowrap; text-align: right; padding-right: 1em;")
-                    }
-                }.style("border-bottom: 1px solid black;")
-
-                for run in PaymentCaseGrouping.runs(payments) {
-                    if showCaseNames {
+            // 以公司（case）為單位：每家公司各自一張表，各帶自己的「服務項目／公費金額」表頭，
+            // 並包在 break-inside: avoid-page 的區塊，避免同一家公司被分頁從中間切開。
+            for (runIndex, run) in PaymentCaseGrouping.runs(payments).enumerated() {
+                Div{
+                    Table{
                         TableRow{
+                            TableCell("服務項目").attribute(named: "colspan", value: "2").style("text-align: center ;")
                             TableCell{
-                                Text(run.caseName ?? "").bold().style("font-size: 1.2em;")
-                            }.attribute(named: "colspan", value: "3")
-                        }.style("padding-top: 0.5em;")
-                    }
-                    for payment in run.payments {
-                        payment.style("font-size: 1rem; padding-bottom: 0.5em; width: 100%;")
-                    }
-                }
+                                Div("公費金額").style("white-space: nowrap; text-align: right; padding-right: 1em;")
+                            }
+                        }.style("border-bottom: 1px solid black;")
 
-            }.style("border-collapse: collapse; width: 100%;")
+                        if showCaseNames {
+                            TableRow{
+                                TableCell{
+                                    Text(run.caseName ?? "").bold().style("font-size: 1.05em;")
+                                }.attribute(named: "colspan", value: "3")
+                            }.style("padding-top: 0.5em;")
+                        }
+                        for payment in run.payments {
+                            payment.style("font-size: 1rem; padding-bottom: 0.5em; width: 100%;")
+                        }
+                    }.style("border-collapse: collapse; width: 100%;")
+                }.style("break-inside: avoid-page;" + (runIndex > 0 ? " margin-top: 1em;" : ""))
+            }
         }
     }
 

--- a/Sources/QuotationHTML/ReplyForm.swift
+++ b/Sources/QuotationHTML/ReplyForm.swift
@@ -53,36 +53,42 @@ public struct ReplyForm: Component{
                         }.style("font-size: 0.875rem;")
                     }
                 }
-                TableRow{
-                    TableCell("附　件：")
-                    if let quotationNo {
-                        TableCell("\(sender.quotationNoPrefix)第\(quotationNo)號公費報價單")
-                    }
-                }
             }.style("width: 100%;")
             Node.br()
-            Table{
-                TableRow{
-                    TableCell().style("width: 102px;")
-                    TableCell(receiver)
-                    TableCell().style("width: 10rem;")
-                }
-                TableRow{
-                    TableCell()
-                    TableCell()
-                    if showCompanyStamp {
-                        TableCell("（公　司　章）　　").style("height: 6rem;vertical-align: top;")
-                    }else{
-                        TableCell("　").style("height: 6rem;vertical-align: top;")
+            // 附件行 + 公司名稱 + 公司章／授權人簽名區塊視為同一區塊，不被分頁切開。
+            Div{
+                Table{
+                    TableRow{
+                        TableCell("附　件：").style("white-space: nowrap; vertical-align: top;")
+                        if let quotationNo {
+                            TableCell("\(sender.quotationNoPrefix)第\(quotationNo)號公費報價單")
+                        }
                     }
-                }
-                
-                TableRow{
-                    TableCell()
-                    TableCell()
-                    TableCell("（授權人簽名或蓋章）").style("height: 6rem;vertical-align: top;")
-                }
-            }.style("width: 100%;")
+                }.style("width: 100%;")
+                Node.br()
+                Table{
+                    TableRow{
+                        TableCell().style("width: 102px;")
+                        TableCell(receiver)
+                        TableCell().style("width: 10rem;")
+                    }
+                    TableRow{
+                        TableCell()
+                        TableCell()
+                        if showCompanyStamp {
+                            TableCell("（公　司　章）　　").style("height: 6rem;vertical-align: top;")
+                        }else{
+                            TableCell("　").style("height: 6rem;vertical-align: top;")
+                        }
+                    }
+
+                    TableRow{
+                        TableCell()
+                        TableCell()
+                        TableCell("（授權人簽名或蓋章）").style("height: 6rem;vertical-align: top;")
+                    }
+                }.style("width: 100%;")
+            }.style("break-inside: avoid-page;")
             Div{
                 Paragraph("中　　華　　民　　國")
                 Paragraph("年")

--- a/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
+++ b/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
@@ -14,36 +14,41 @@ public struct ReplyFormPaymentBlock: Component {
         // 多 case 時與主酬金一致：每個 case 第一個 bundle 上方加 case 名稱標題。
         let showCaseNames = PaymentCaseGrouping.showsCaseNames(payments)
         return ComponentGroup {
-            Table {
-                for run in PaymentCaseGrouping.runs(payments) {
-                    if showCaseNames {
-                        TableRow{
-                            TableCell(Text(run.caseName ?? "").bold().style("font-size: 1.1em;")).attribute(named: "colspan", value: "3").style("vertical-align: middle;")
-                        }
-                    }
-                    for payment in run.payments {
-                        if payment.needShowName {
+            // 以公司（case）為單位，每個 run 各自成一張表並包在 break-inside: avoid 的區塊，
+            // 避免同一家公司的酬金被分頁從中間切開。各表皆 width: 100% 且金額欄靠右，
+            // 故跨公司的金額右緣仍對齊。
+            for run in PaymentCaseGrouping.runs(payments) {
+                Div {
+                    Table {
+                        if showCaseNames {
                             TableRow{
-                                TableCell(Text(payment.name).bold()).attribute(named: "colspan", value: "3").style("vertical-align: middle;")
+                                TableCell(Text(run.caseName ?? "").bold().style("font-size: 1.1em;")).attribute(named: "colspan", value: "3").style("vertical-align: middle;")
                             }
                         }
+                        for payment in run.payments {
+                            if payment.needShowName {
+                                TableRow{
+                                    TableCell(Text(payment.name).bold()).attribute(named: "colspan", value: "3").style("vertical-align: middle;")
+                                }
+                            }
 
-                        for (index, item) in payment.items.enumerated() {
-                            TableRow {
-                                TableCell("(\(index+1))").style("vertical-align: top;")
-                                TableCell {
-                                    for line in item.lines {
-                                        Div(line)
-                                    }
-                                }.style("vertical-align: top; width: 100%;")
-                                TableCell{
-                                    Text(item.fee.displayText)
-                                }.style("vertical-align: top; text-align: right; white-space: nowrap;")
+                            for (index, item) in payment.items.enumerated() {
+                                TableRow {
+                                    TableCell("(\(index+1))").style("vertical-align: top;")
+                                    TableCell {
+                                        for line in item.lines {
+                                            Div(line)
+                                        }
+                                    }.style("vertical-align: top; width: 100%;")
+                                    TableCell{
+                                        Text(item.fee.displayText)
+                                    }.style("vertical-align: top; text-align: right; white-space: nowrap;")
+                                }
                             }
                         }
-                    }
-                }
-            }.style("font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;")
+                    }.style("font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;")
+                }.style("break-inside: avoid-page;")
+            }
         }
     }
     

--- a/Sources/QuotationHTML/SupplementaryNoteHTMLRenderer.swift
+++ b/Sources/QuotationHTML/SupplementaryNoteHTMLRenderer.swift
@@ -21,26 +21,37 @@ import Markdown
 ///   margin 歸零讓標題與一般段落行距一致。
 enum SupplementaryNoteHTMLRenderer {
 
-    static func render(markdown: String) -> String {
+    /// - Parameter marker: 補充說明開頭要顯示的標記字元（例：`"*"`）。以 scoped `::before` inject 到
+    ///   第一個 block 的行首，故與內文同一行、且不會被 markdown parser 誤判（不污染 caller 的 markdown 字串）。
+    ///   `nil` 則不加標記。
+    static func render(markdown: String, marker: String? = nil) -> String {
         let document = Document(parsing: markdown)
         var rewriter = SoftBreakToLineBreakRewriter()
         let rewritten = rewriter.visit(document) ?? document
         let body = HTMLFormatter.format(rewritten)
-        return scopedStyleBlock + "<div class=\"rich-supplementaryNote\">\(body)</div>"
+        let markerClass = marker == nil ? "" : " with-marker"
+        return scopedStyleBlock(marker: marker) + "<div class=\"rich-supplementaryNote\(markerClass)\">\(body)</div>"
     }
 
-    static let scopedStyleBlock: String = """
-    <style>
-    .rich-supplementaryNote table { border-collapse: collapse; }
-    .rich-supplementaryNote table td,
-    .rich-supplementaryNote table th { border: 1px solid #999; padding: 0.15em 0.5em; }
-    .rich-supplementaryNote img { max-width: 200px; height: auto; }
-    .rich-supplementaryNote p,
-    .rich-supplementaryNote h1, .rich-supplementaryNote h2, .rich-supplementaryNote h3,
-    .rich-supplementaryNote h4, .rich-supplementaryNote h5, .rich-supplementaryNote h6,
-    .rich-supplementaryNote ul, .rich-supplementaryNote ol { margin: 0; }
-    </style>
-    """
+    static func scopedStyleBlock(marker: String? = nil) -> String {
+        // marker 用 `::before` 加在第一個 block（通常是 `<p>`）行首，與內文同一行；換行時後續行回到區塊左緣。
+        let markerRule = marker.map {
+            ".rich-supplementaryNote.with-marker > :first-child::before { content: \"\($0)\"; }"
+        } ?? ""
+        return """
+        <style>
+        .rich-supplementaryNote table { border-collapse: collapse; }
+        .rich-supplementaryNote table td,
+        .rich-supplementaryNote table th { border: 1px solid #999; padding: 0.15em 0.5em; }
+        .rich-supplementaryNote img { max-width: 200px; height: auto; }
+        .rich-supplementaryNote p,
+        .rich-supplementaryNote h1, .rich-supplementaryNote h2, .rich-supplementaryNote h3,
+        .rich-supplementaryNote h4, .rich-supplementaryNote h5, .rich-supplementaryNote h6,
+        .rich-supplementaryNote ul, .rich-supplementaryNote ol { margin: 0; }
+        \(markerRule)
+        </style>
+        """
+    }
 }
 
 /// 把 markdown AST 的 `SoftBreak`（段落內單一 `\n`）改寫成 `LineBreak`（HTML `<br>`）。

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -84,7 +84,7 @@ import Foundation
 
     let payment = Payment(name: title, items: items)
     #expect(payment.render() == """
-    <tr><td colspan="3"><b style="font-size: 1.1em;">酬金</b></td></tr><tr style="padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr><tr style="padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;"><td style="vertical-align: top; width: 1.35rem;">(2)</td><td><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">6,000 元/年</td></tr>
+    <tr><td colspan="3"><b style="font-size: 0.95em;">酬金</b></td></tr><tr style="padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;"><td style="vertical-align: top; width: 1.35rem;">1.</td><td><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr><tr style="padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;"><td style="vertical-align: top; width: 1.35rem;">2.</td><td><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">6,000 元/年</td></tr>
     """)
 }
 
@@ -96,16 +96,18 @@ import Foundation
         ],
         supplementaryNote: "財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"
     )
-    // 2026-06：拔掉 `white-space: pre-line` legacy style + 拔掉硬寫的 `*` 前綴 — HTML 時代由
-    // caller 決定 marker / 換行；本 row 保留 `padding-top: 0.5em` 與 `colspan="2"`。
+    // 2026-07：補充說明改回 `*` 標記（marker 由 renderer 以 scoped `::before` inject 到行首）+ 拿掉上方橫線。
+    // marker 走 CSS content，不硬寫進文字節點；換行 legacy style 不再 emit。
     let rendered = payment.render()
     #expect(rendered.contains("財務簽證依預估資產總額新台幣壹億元報價"))
-    // `colspan="2"` + `padding-top: 0.5em` 組合鎖補充說明 cell — 單獨 `padding-top: 0.5em` 會被
-    // item row 的 style 誤命中（item row 也含此 declaration）；`colspan="2"` 是補充說明 row 唯一特徵。
-    #expect(rendered.contains("colspan=\"2\" style=\"border-top: 1px solid black; padding-top: 0.5em;\""),
-        "補充說明 cell 應帶上方分隔線 + 保留 padding-top（搭 colspan=2 與 item row 區隔）")
+    // 補充說明 cell 的唯一特徵：套 `with-marker` class（`*` 標記）。
+    #expect(rendered.contains("<div class=\"rich-supplementaryNote with-marker\">"),
+        "補充說明應套用 with-marker（* 標記）")
+    #expect(rendered.contains(".rich-supplementaryNote.with-marker > :first-child::before { content: \"*\"; }"),
+        "`*` 標記應以 scoped ::before 呈現")
+    #expect(!rendered.contains("border-top: 1px solid black"), "不應再畫上方分隔線（改用 * 標記）")
     #expect(!rendered.contains("white-space: pre-line"), "legacy pre-line style 不應再被 emit")
-    #expect(!rendered.contains(">*財務簽證"), "硬寫的 `*` 前綴不應再被 emit — caller 自行決定 marker")
+    #expect(!rendered.contains(">*財務簽證"), "`*` 應由 ::before 呈現、非硬寫進文字節點")
 }
 
 @Test func paymentOmitsSupplementaryNoteRowWhenNil(){
@@ -164,14 +166,14 @@ import Foundation
             .init(names: ["World"], fee: .yearly(6000))
         ])
     ], """
-    <p style="font-size: 1.1rem;">酬金</p><table style="border-collapse: collapse; width: 100%;"><tr style="border-bottom: 1px solid black;"><td colspan="2" style="text-align: center ;">服務項目</td><td><div style="white-space: nowrap; text-align: right; padding-right: 1em;">公費金額</div></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td colspan="3"><b style="font-size: 1.1em;">****作業(112 年度)</b></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>Hello</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/月</td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td colspan="3"><b style="font-size: 1.1em;">****作業(113 年起)</b></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(2)</td><td><div>World</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">6,000 元/年</td></tr></table>
+    <p style="font-size: 1.1rem;">酬金</p><div style="break-inside: avoid-page;"><table style="border-collapse: collapse; width: 100%;"><tr style="border-bottom: 1px solid black;"><td colspan="2" style="text-align: center ;">服務項目</td><td><div style="white-space: nowrap; text-align: right; padding-right: 1em;">公費金額</div></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td colspan="3"><b style="font-size: 0.95em;">****作業(112 年度)</b></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">1.</td><td><div>Hello</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/月</td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td colspan="3"><b style="font-size: 0.95em;">****作業(113 年起)</b></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">1.</td><td><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">2.</td><td><div>World</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">6,000 元/年</td></tr></table></div>
     """),
     ([
         Payment(name: "****作業(112 年度)", items: [
             .init(names: ["Hello"], fee: .yearly(5000))
         ])
     ], """
-    <p style="font-size: 1.1rem;">酬金</p><table style="border-collapse: collapse; width: 100%;"><tr style="border-bottom: 1px solid black;"><td colspan="2" style="text-align: center ;">服務項目</td><td><div style="white-space: nowrap; text-align: right; padding-right: 1em;">公費金額</div></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">(1)</td><td><div>Hello</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr></table>
+    <p style="font-size: 1.1rem;">酬金</p><div style="break-inside: avoid-page;"><table style="border-collapse: collapse; width: 100%;"><tr style="border-bottom: 1px solid black;"><td colspan="2" style="text-align: center ;">服務項目</td><td><div style="white-space: nowrap; text-align: right; padding-right: 1em;">公費金額</div></td></tr><tr style="font-size: 1rem; padding-bottom: 0.5em; width: 100%;"><td style="vertical-align: top; width: 1.35rem;">1.</td><td><div>Hello</div></td><td style="text-align: right; vertical-align: top; white-space: nowrap; padding-right: 0.5em;">5,000 元/年</td></tr></table></div>
     """)
 ])
 func createPaymentBlocHtml(payments: [Payment], result: String){
@@ -191,12 +193,12 @@ func paymentBlockRendersCaseHeadingsWhenMultipleCases() {
     ]
     let rendered = PaymentBlock(title: "酬金", payments: payments).render()
 
-    // 兩個不同 case → 各自的 case 名稱標題（1.2em bold）。
-    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">甲公司</b>"))
-    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">乙公司</b>"))
-    // 甲公司有 ≥2 個 bundle → bundle 名（1.1em）照顯示。
-    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃1</b>"))
-    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃2</b>"))
+    // 兩個不同 case → 各自的 case 名稱標題（1.05em bold）。
+    #expect(rendered.contains("<b style=\"font-size: 1.05em;\">甲公司</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.05em;\">乙公司</b>"))
+    // 甲公司有 ≥2 個 bundle → bundle 名（0.95em）照顯示。
+    #expect(rendered.contains("<b style=\"font-size: 0.95em;\">規劃1</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 0.95em;\">規劃2</b>"))
     // 乙公司只有 1 個 bundle → bundle 名隱藏（即使在合併顯示多 case 情境）。
     #expect(!rendered.contains("乙方案"), "單一 bundle 的 case 不應顯示 bundle 名")
     // 甲公司標題排在乙公司之前（依輸入 case 順序）。
@@ -216,8 +218,8 @@ func paymentBlockCountsBundlesPerCaseRegardlessOfOrder() {
     let rendered = PaymentBlock(title: "酬金", payments: payments).render()
 
     // 甲公司總共 2 個 bundle → bundle 名照顯示（不因被乙公司隔開而誤隱藏）。
-    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃1</b>"))
-    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃2</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 0.95em;\">規劃1</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 0.95em;\">規劃2</b>"))
     // 乙公司只有 1 個 bundle → 隱藏。
     #expect(!rendered.contains("乙方案"), "單一 bundle 的 case 不應顯示 bundle 名")
 }
@@ -231,8 +233,8 @@ func paymentBlockHidesSingleBundleNamePerCaseInMergedView() {
     ]
     let rendered = PaymentBlock(title: "酬金", payments: payments).render()
 
-    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">甲公司</b>"))
-    #expect(rendered.contains("<b style=\"font-size: 1.2em;\">乙公司</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.05em;\">甲公司</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.05em;\">乙公司</b>"))
     #expect(!rendered.contains("甲方案"), "單一 bundle 的 case 不應顯示 bundle 名")
     #expect(!rendered.contains("乙方案"), "單一 bundle 的 case 不應顯示 bundle 名")
 }
@@ -246,9 +248,10 @@ func paymentBlockOmitsCaseHeadingWhenSingleCase() {
     ]
     let rendered = PaymentBlock(title: "酬金", payments: payments).render()
 
-    #expect(!rendered.contains("font-size: 1.2em;"), "單一 case 不應出現 case 名稱標題")
-    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃1</b>"))
-    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">規劃2</b>"))
+    // 單一 case 不渲染 case 名稱標題 → caseName 文字（甲公司）完全不出現（case 名只會以標題形式出現）。
+    #expect(!rendered.contains("甲公司"), "單一 case 不應出現 case 名稱標題")
+    #expect(rendered.contains("<b style=\"font-size: 0.95em;\">規劃1</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 0.95em;\">規劃2</b>"))
 }
 
 
@@ -313,7 +316,7 @@ func paymentBlockOmitsCaseHeadingWhenSingleCase() {
 
     let replyForm = ReplyForm(receiver: receiver, sender: sender, subject: subject, payments: payments, additionalServices: additionalServices, quotationNo: quotationNo)
     #expect(replyForm.render() == """
-<h2 style="text-align: center;">同意函</h2><table style="width: 100%;"><tr><td style="width: 70px; white-space: nowrap; vertical-align: top">受文者：</td><td>嘉威聯合會計師事務所</td></tr><tr><td style="white-space: nowrap; vertical-align: top">主　旨：</td><td>本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。</td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top">酬　金：</td></tr><tr><td></td><td><table style="font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;"><tr><td style="vertical-align: top;">(1)</td><td style="vertical-align: top; width: 100%;"><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">5,000 元/年</td></tr><tr><td style="vertical-align: top;">(2)</td><td style="vertical-align: top; width: 100%;"><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">6,000 元/月</td></tr></table></td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top;">附加服務請勾選：</td></tr><tr style="font-size: 0.875rem;"><td></td><td>□代辦年度CTP申報(每年3月；加收2,000元/家)</td></tr><tr style="font-size: 0.875rem;"><td></td><td>☑二代健保申報作業</td></tr><tr><td>附　件：</td><td>嘉威稅字第111112101號公費報價單</td></tr></table><br/><table style="width: 100%;"><tr><td style="width: 102px;"></td><td>全家人健康事業股份有限公司</td><td style="width: 10rem;"></td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（公　司　章）　　</td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（授權人簽名或蓋章）</td></tr></table><div style="display: flex; justify-content: space-between; width: 100%; margin: 0 auto; position: absolute; bottom: 0px;"><p>中　　華　　民　　國</p><p>年</p><p>月</p><p>日</p></div>
+<h2 style="text-align: center;">同意函</h2><table style="width: 100%;"><tr><td style="width: 70px; white-space: nowrap; vertical-align: top">受文者：</td><td>嘉威聯合會計師事務所</td></tr><tr><td style="white-space: nowrap; vertical-align: top">主　旨：</td><td>本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。</td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top">酬　金：</td></tr><tr><td></td><td><div style="break-inside: avoid-page;"><table style="font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;"><tr><td style="vertical-align: top;">(1)</td><td style="vertical-align: top; width: 100%;"><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">5,000 元/年</td></tr><tr><td style="vertical-align: top;">(2)</td><td style="vertical-align: top; width: 100%;"><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">6,000 元/月</td></tr></table></div></td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top;">附加服務請勾選：</td></tr><tr style="font-size: 0.875rem;"><td></td><td>□代辦年度CTP申報(每年3月；加收2,000元/家)</td></tr><tr style="font-size: 0.875rem;"><td></td><td>☑二代健保申報作業</td></tr></table><br/><div style="break-inside: avoid-page;"><table style="width: 100%;"><tr><td style="white-space: nowrap; vertical-align: top;">附　件：</td><td>嘉威稅字第111112101號公費報價單</td></tr></table><br/><table style="width: 100%;"><tr><td style="width: 102px;"></td><td>全家人健康事業股份有限公司</td><td style="width: 10rem;"></td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（公　司　章）　　</td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（授權人簽名或蓋章）</td></tr></table></div><div style="display: flex; justify-content: space-between; width: 100%; margin: 0 auto; position: absolute; bottom: 0px;"><p>中　　華　　民　　國</p><p>年</p><p>月</p><p>日</p></div>
 """)
 }
 
@@ -337,7 +340,7 @@ func paymentBlockOmitsCaseHeadingWhenSingleCase() {
 
     let replyForm = ReplyForm(receiver: receiver, sender: sender, subject: subject, payments: payments, additionalServices: additionalServices, quotationNo: quotationNo, showCompanyStamp: false)
     #expect(replyForm.render() == """
-<h2 style="text-align: center;">同意函</h2><table style="width: 100%;"><tr><td style="width: 70px; white-space: nowrap; vertical-align: top">受文者：</td><td>嘉威聯合會計師事務所</td></tr><tr><td style="white-space: nowrap; vertical-align: top">主　旨：</td><td>本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。</td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top">酬　金：</td></tr><tr><td></td><td><table style="font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;"><tr><td style="vertical-align: top;">(1)</td><td style="vertical-align: top; width: 100%;"><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">5,000 元/年</td></tr><tr><td style="vertical-align: top;">(2)</td><td style="vertical-align: top; width: 100%;"><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">6,000 元/月</td></tr></table></td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top;">附加服務請勾選：</td></tr><tr style="font-size: 0.875rem;"><td></td><td>□代辦年度CTP申報(每年3月；加收2,000元/家)</td></tr><tr style="font-size: 0.875rem;"><td></td><td>☑二代健保申報作業</td></tr><tr><td>附　件：</td><td>嘉威稅字第111112101號公費報價單</td></tr></table><br/><table style="width: 100%;"><tr><td style="width: 102px;"></td><td>全家人健康事業股份有限公司</td><td style="width: 10rem;"></td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">　</td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（授權人簽名或蓋章）</td></tr></table><div style="display: flex; justify-content: space-between; width: 100%; margin: 0 auto; position: absolute; bottom: 0px;"><p>中　　華　　民　　國</p><p>年</p><p>月</p><p>日</p></div>
+<h2 style="text-align: center;">同意函</h2><table style="width: 100%;"><tr><td style="width: 70px; white-space: nowrap; vertical-align: top">受文者：</td><td>嘉威聯合會計師事務所</td></tr><tr><td style="white-space: nowrap; vertical-align: top">主　旨：</td><td>本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。</td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top">酬　金：</td></tr><tr><td></td><td><div style="break-inside: avoid-page;"><table style="font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;"><tr><td style="vertical-align: top;">(1)</td><td style="vertical-align: top; width: 100%;"><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">5,000 元/年</td></tr><tr><td style="vertical-align: top;">(2)</td><td style="vertical-align: top; width: 100%;"><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">6,000 元/月</td></tr></table></div></td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top;">附加服務請勾選：</td></tr><tr style="font-size: 0.875rem;"><td></td><td>□代辦年度CTP申報(每年3月；加收2,000元/家)</td></tr><tr style="font-size: 0.875rem;"><td></td><td>☑二代健保申報作業</td></tr></table><br/><div style="break-inside: avoid-page;"><table style="width: 100%;"><tr><td style="white-space: nowrap; vertical-align: top;">附　件：</td><td>嘉威稅字第111112101號公費報價單</td></tr></table><br/><table style="width: 100%;"><tr><td style="width: 102px;"></td><td>全家人健康事業股份有限公司</td><td style="width: 10rem;"></td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">　</td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（授權人簽名或蓋章）</td></tr></table></div><div style="display: flex; justify-content: space-between; width: 100%; margin: 0 auto; position: absolute; bottom: 0px;"><p>中　　華　　民　　國</p><p>年</p><p>月</p><p>日</p></div>
 """)
 }
 
@@ -360,7 +363,7 @@ func paymentBlockOmitsCaseHeadingWhenSingleCase() {
 
     let replyForm = ReplyForm(receiver: receiver, sender: sender, subject: subject, payments: payments, additionalServices: additionalServices, quotationNo: quotationNo)
     #expect(replyForm.render() == """
-<h2 style="text-align: center;">同意函</h2><table style="width: 100%;"><tr><td style="width: 70px; white-space: nowrap; vertical-align: top">受文者：</td><td>嘉威聯合會計師事務所</td></tr><tr><td style="white-space: nowrap; vertical-align: top">主　旨：</td><td>本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。</td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top">酬　金：</td></tr><tr><td></td><td><table style="font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;"><tr><td style="vertical-align: top;">(1)</td><td style="vertical-align: top; width: 100%;"><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">5,000 元/年</td></tr><tr><td style="vertical-align: top;">(2)</td><td style="vertical-align: top; width: 100%;"><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">6,000 元/月</td></tr></table></td></tr><tr><td>附　件：</td><td>嘉威稅字第111112101號公費報價單</td></tr></table><br/><table style="width: 100%;"><tr><td style="width: 102px;"></td><td>全家人健康事業股份有限公司</td><td style="width: 10rem;"></td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（公　司　章）　　</td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（授權人簽名或蓋章）</td></tr></table><div style="display: flex; justify-content: space-between; width: 100%; margin: 0 auto; position: absolute; bottom: 0px;"><p>中　　華　　民　　國</p><p>年</p><p>月</p><p>日</p></div>
+<h2 style="text-align: center;">同意函</h2><table style="width: 100%;"><tr><td style="width: 70px; white-space: nowrap; vertical-align: top">受文者：</td><td>嘉威聯合會計師事務所</td></tr><tr><td style="white-space: nowrap; vertical-align: top">主　旨：</td><td>本公司同意委託貴事務所執行本公司有關營利事業所得稅查核簽證與未分配盈餘查核簽證及財會委外處理作業之專業服務項目及公費，請查照。</td></tr><tr><td></td><td style="white-space: nowrap; vertical-align: top">酬　金：</td></tr><tr><td></td><td><div style="break-inside: avoid-page;"><table style="font-size: 0.875rem; width: 100%; border-collapse: separate; border-spacing: 0.2em;"><tr><td style="vertical-align: top;">(1)</td><td style="vertical-align: top; width: 100%;"><div>民國 113 年度之營利事業所得稅查核簽證與未分配盈餘查核簽證</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">5,000 元/年</td></tr><tr><td style="vertical-align: top;">(2)</td><td style="vertical-align: top; width: 100%;"><div>會計帳務處理作業（113 年 5 月開始）</div></td><td style="vertical-align: top; text-align: right; white-space: nowrap;">6,000 元/月</td></tr></table></div></td></tr></table><br/><div style="break-inside: avoid-page;"><table style="width: 100%;"><tr><td style="white-space: nowrap; vertical-align: top;">附　件：</td><td>嘉威稅字第111112101號公費報價單</td></tr></table><br/><table style="width: 100%;"><tr><td style="width: 102px;"></td><td>全家人健康事業股份有限公司</td><td style="width: 10rem;"></td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（公　司　章）　　</td></tr><tr><td></td><td></td><td style="height: 6rem;vertical-align: top;">（授權人簽名或蓋章）</td></tr></table></div><div style="display: flex; justify-content: space-between; width: 100%; margin: 0 auto; position: absolute; bottom: 0px;"><p>中　　華　　民　　國</p><p>年</p><p>月</p><p>日</p></div>
 """)
 }
 


### PR DESCRIPTION
## 摘要

調整報價單（AuditQuotation）酬金與同意函的分頁行為與版面格式。

### 同意函（ReplyForm）
- 酬金以**公司為單位**、附件＋公司名＋公司章/授權人簽章視為**同一區塊**，各自 `break-inside: avoid-page`，避免被分頁從中間切開。

### 本文「四、酬金」（PaymentBlock）
- **每家公司各自一張表**、各帶「服務項目／公費金額」表頭，並 `break-inside: avoid-page` → 同一家公司不會被分頁切開。
- 服務項目編號 `(1)` → `1.`。
- 補充說明改以 `*` 標記開頭（marker 由 renderer 以 scoped `::before` inject 到行首，不污染 caller 的 markdown）、拿掉上方橫線。
- 字級：公司名 `1.2em → 1.05em`、報價規劃（bundle）名 `1.1em → 0.95em`，皆保留粗體，拉出「公司 > 報價規劃 > 項目」三層。

### SupplementaryNoteHTMLRenderer
- 新增 `marker` 參數（scoped `::before`）。

## 測試
- golden／assertion 全數同步更新，`swift test` 48 tests 全綠。

## ⚠️ 部署注意（非本 PR 程式）
粗體標題設計為使用 **特粗楷體**（`b { font-family: '特粗楷體' }` + `@font-face`）。正式 Linux 主機需將字型檔以確切檔名 `特粗楷體.TTC` 放到 `/usr/local/share/fonts/`，否則粗體會退回合成粗體。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 补充说明改为在内容行首显示“*”标记，版式更清晰。
  - 不同公司或项目的费用明细分别分组展示，并保留完整表头。
  - 附件、签名及盖章区域在分页时尽量保持完整。

- **界面优化**
  - 调整公司名称、费用标题及项目编号的字号与格式。
  - 优化费用列对齐、换行及表格间距，提升 PDF 阅读体验。

- **测试**
  - 更新 PDF 生成相关验证，覆盖新的表格结构与分页表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->