### PR TITLE
[CHANGE] 移除酬金補充說明的 * 標記

### DIFF
--- a/Sources/QuotationHTML/Payment.swift
+++ b/Sources/QuotationHTML/Payment.swift
@@ -23,8 +23,7 @@ public struct Payment: Component {
     /// `nil` 或空字串 → 不渲染此 row。
     ///
     /// **渲染重點**：
-    /// - 補充說明 row 為跨整欄（colspan=3）cell，內文以 `*` 標記開頭（marker 由 renderer 以 scoped
-    ///   `::before` inject 到行首，與內文同一行）；不再畫上方橫線。
+    /// - 補充說明 row 為跨整欄（colspan=3）cell，上方留 padding；不加標記符號、不畫橫線。
     /// - markdown / 樣式細節見 `SupplementaryNoteHTMLRenderer`。
     public let supplementaryNote: String?
 
@@ -44,11 +43,10 @@ public struct Payment: Component {
                 }.style("padding-bottom: 0.5em; width: 100%; padding-top: 0.5em;")
             }
             if let supplementaryNote, !supplementaryNote.isEmpty {
-                // 補充說明以 `*` 標記開頭（不再畫上方橫線）：marker 由 renderer 以 scoped `::before` inject
-                // 到內文行首，故與內文同一行、且不污染 caller 的 markdown。整段跨欄（colspan=3）從左緣起排。
+                // 補充說明：整段跨欄（colspan=3）從左緣起排、上方留 padding，不加任何標記或橫線。
                 // markdown → HTML 在此渲染（presentation 歸 PDFGenerator）；caller 傳的是 markdown。
                 TableRow{
-                    TableCell(html: SupplementaryNoteHTMLRenderer.render(markdown: supplementaryNote, marker: "*"))
+                    TableCell(html: SupplementaryNoteHTMLRenderer.render(markdown: supplementaryNote))
                         .attribute(named: "colspan", value: "3")
                         .style("padding-top: 0.5em;")
                 }

--- a/Sources/QuotationHTML/SupplementaryNoteHTMLRenderer.swift
+++ b/Sources/QuotationHTML/SupplementaryNoteHTMLRenderer.swift
@@ -21,37 +21,26 @@ import Markdown
 ///   margin 歸零讓標題與一般段落行距一致。
 enum SupplementaryNoteHTMLRenderer {
 
-    /// - Parameter marker: 補充說明開頭要顯示的標記字元（例：`"*"`）。以 scoped `::before` inject 到
-    ///   第一個 block 的行首，故與內文同一行、且不會被 markdown parser 誤判（不污染 caller 的 markdown 字串）。
-    ///   `nil` 則不加標記。
-    static func render(markdown: String, marker: String? = nil) -> String {
+    static func render(markdown: String) -> String {
         let document = Document(parsing: markdown)
         var rewriter = SoftBreakToLineBreakRewriter()
         let rewritten = rewriter.visit(document) ?? document
         let body = HTMLFormatter.format(rewritten)
-        let markerClass = marker == nil ? "" : " with-marker"
-        return scopedStyleBlock(marker: marker) + "<div class=\"rich-supplementaryNote\(markerClass)\">\(body)</div>"
+        return scopedStyleBlock + "<div class=\"rich-supplementaryNote\">\(body)</div>"
     }
 
-    static func scopedStyleBlock(marker: String? = nil) -> String {
-        // marker 用 `::before` 加在第一個 block（通常是 `<p>`）行首，與內文同一行；換行時後續行回到區塊左緣。
-        let markerRule = marker.map {
-            ".rich-supplementaryNote.with-marker > :first-child::before { content: \"\($0)\"; }"
-        } ?? ""
-        return """
-        <style>
-        .rich-supplementaryNote table { border-collapse: collapse; }
-        .rich-supplementaryNote table td,
-        .rich-supplementaryNote table th { border: 1px solid #999; padding: 0.15em 0.5em; }
-        .rich-supplementaryNote img { max-width: 200px; height: auto; }
-        .rich-supplementaryNote p,
-        .rich-supplementaryNote h1, .rich-supplementaryNote h2, .rich-supplementaryNote h3,
-        .rich-supplementaryNote h4, .rich-supplementaryNote h5, .rich-supplementaryNote h6,
-        .rich-supplementaryNote ul, .rich-supplementaryNote ol { margin: 0; }
-        \(markerRule)
-        </style>
-        """
-    }
+    static let scopedStyleBlock: String = """
+    <style>
+    .rich-supplementaryNote table { border-collapse: collapse; }
+    .rich-supplementaryNote table td,
+    .rich-supplementaryNote table th { border: 1px solid #999; padding: 0.15em 0.5em; }
+    .rich-supplementaryNote img { max-width: 200px; height: auto; }
+    .rich-supplementaryNote p,
+    .rich-supplementaryNote h1, .rich-supplementaryNote h2, .rich-supplementaryNote h3,
+    .rich-supplementaryNote h4, .rich-supplementaryNote h5, .rich-supplementaryNote h6,
+    .rich-supplementaryNote ul, .rich-supplementaryNote ol { margin: 0; }
+    </style>
+    """
 }
 
 /// 把 markdown AST 的 `SoftBreak`（段落內單一 `\n`）改寫成 `LineBreak`（HTML `<br>`）。

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -96,18 +96,17 @@ import Foundation
         ],
         supplementaryNote: "財務簽證依預估資產總額新台幣壹億元報價\n會計帳務處理作業依照預估年營收貳億伍仟萬元報價。"
     )
-    // 2026-07：補充說明改回 `*` 標記（marker 由 renderer 以 scoped `::before` inject 到行首）+ 拿掉上方橫線。
-    // marker 走 CSS content，不硬寫進文字節點；換行 legacy style 不再 emit。
+    // 2026-07：補充說明不加任何標記符號、不畫上方橫線；僅以 markdown 渲染的內文呈現。
     let rendered = payment.render()
     #expect(rendered.contains("財務簽證依預估資產總額新台幣壹億元報價"))
-    // 補充說明 cell 的唯一特徵：套 `with-marker` class（`*` 標記）。
-    #expect(rendered.contains("<div class=\"rich-supplementaryNote with-marker\">"),
-        "補充說明應套用 with-marker（* 標記）")
-    #expect(rendered.contains(".rich-supplementaryNote.with-marker > :first-child::before { content: \"*\"; }"),
-        "`*` 標記應以 scoped ::before 呈現")
-    #expect(!rendered.contains("border-top: 1px solid black"), "不應再畫上方分隔線（改用 * 標記）")
+    // 補充說明 cell：純 rich-supplementaryNote，不帶 marker。
+    #expect(rendered.contains("<div class=\"rich-supplementaryNote\">"),
+        "補充說明應以 rich-supplementaryNote 呈現")
+    #expect(!rendered.contains("with-marker"), "不應再套 with-marker（* 標記已移除）")
+    #expect(!rendered.contains("::before"), "不應再有 * marker 的 ::before 規則")
+    #expect(!rendered.contains("border-top: 1px solid black"), "不應再畫上方分隔線")
     #expect(!rendered.contains("white-space: pre-line"), "legacy pre-line style 不應再被 emit")
-    #expect(!rendered.contains(">*財務簽證"), "`*` 應由 ::before 呈現、非硬寫進文字節點")
+    #expect(!rendered.contains(">*財務簽證"), "不應出現硬寫的 * 前綴")
 }
 
 @Test func paymentOmitsSupplementaryNoteRowWhenNil(){


### PR DESCRIPTION
## 摘要

移除本文「四、酬金」補充說明行首的 `*` 標記。補充說明現在只顯示 markdown 渲染的內文（上方留 padding），不加標記符號、也不畫橫線。

- `Payment.swift`：補充說明改呼叫 `render(markdown:)`（不再傳 `marker`）。
- `SupplementaryNoteHTMLRenderer.swift`：移除已無使用者的 `marker` 參數與 `with-marker` / `::before` 邏輯。

## 測試
- `paymentRendersSupplementaryNoteRowWhenProvided` 更新為驗證「不含 with-marker / ::before」。
- `swift test` 48 tests 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化酬金补充说明的显示方式。
  * 跨栏补充说明不再自动添加“*”等行首标记，内容将以更简洁的无标记样式呈现。
  * 调整相关排版样式，保持文字、列表、标题及图片的清晰显示。

* **测试**
  * 更新显示验证，确保补充说明不会出现旧版标记或遗留样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->