### PR TITLE
[FIX] 同意函單 bundle 的 case 隱藏規劃名（per-case 判斷，與主酬金一致）

### DIFF
--- a/Sources/QuotationHTML/PaymentBlock.swift
+++ b/Sources/QuotationHTML/PaymentBlock.swift
@@ -46,16 +46,7 @@ public struct PaymentBlock: Component {
 
     public init(title: String, payments: [Payment]) {
         self.title = title
-        // 「單 bundle 不顯示 bundle 名」規則 per-case 套用：每個 case **總共**只有 1 個 bundle 時隱藏 bundle 名
-        // （該 case 的 case 標題已足夠識別），兩種情境一致：
-        // - 多 case（合併顯示）：各 case 名標題照渲染；其中只有 1 個 bundle 的 case 隱藏其 bundle 名，
-        //   只有 ≥2 bundle 的 case 才逐一顯示 bundle 名。
-        // - 單一 case（分開顯示 / case 名標題不渲染）：單 bundle 同樣隱藏 bundle 名。
-        // 用「per-caseName 總數」而非連續 run 數，避免同 case bundle 在輸入中非連續時被誤判為各自單 bundle。
-        let bundleCountByCase = Dictionary(grouping: payments, by: \.caseName).mapValues(\.count)
-        self.payments = payments.map { payment in
-            (bundleCountByCase[payment.caseName] ?? 0) == 1 ? payment.hideName() : payment
-        }
+        self.payments = PaymentCaseGrouping.hidingSingleBundleNames(payments)
     }
     
     public init(title: String = "酬金", payments models: [Payment.Model]) {

--- a/Sources/QuotationHTML/PaymentCaseGrouping.swift
+++ b/Sources/QuotationHTML/PaymentCaseGrouping.swift
@@ -27,4 +27,14 @@ enum PaymentCaseGrouping {
     static func showsCaseNames(_ payments: [Payment]) -> Bool {
         runs(payments).count > 1
     }
+
+    /// 「單 bundle 不顯示 bundle 名」規則 per-case 套用：每個 case **總共**只有 1 個 bundle 時
+    /// 隱藏其 bundle 名（該 case 的 case 標題已足夠識別；單一 case 亦同——單 bundle 隱藏、多 bundle 照顯示）。
+    /// 用「per-caseName 總數」而非連續 run 數，避免同 case bundle 在輸入中非連續時被誤判為各自單 bundle。
+    static func hidingSingleBundleNames(_ payments: [Payment]) -> [Payment] {
+        let bundleCountByCase = Dictionary(grouping: payments, by: \.caseName).mapValues(\.count)
+        return payments.map { payment in
+            (bundleCountByCase[payment.caseName] ?? 0) == 1 ? payment.hideName() : payment
+        }
+    }
 }

--- a/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
+++ b/Sources/QuotationHTML/ReplyFormPaymentBlock.swift
@@ -52,13 +52,8 @@ public struct ReplyFormPaymentBlock: Component {
         }
     }
     
-    public init(payments: [Payment]) {        
-        self.payments = if payments.count == 1 {
-            payments.map{
-                $0.hideName()
-            }
-        }else{
-            payments
-        }
+    public init(payments: [Payment]) {
+        // 與主酬金 PaymentBlock 一致：單 bundle 的 case 隱藏 bundle 名（per-case 判斷，非全域 count）。
+        self.payments = PaymentCaseGrouping.hidingSingleBundleNames(payments)
     }
 }

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -264,6 +264,53 @@ func paymentBlockOmitsCaseHeadingWhenSingleCase() {
     #expect(rendered.contains("<b style=\"font-size: 0.95em;\">規劃2</b>"))
 }
 
+@Test("reply form: single-bundle case hides bundle name even in merged (multi-case) view")
+func replyFormPaymentBlockHidesSingleBundleNamePerCaseInMergedView() {
+    // 兩個 case 各只有 1 個 bundle → case 標題照渲染、但兩個 bundle 名都隱藏（與主酬金 PaymentBlock 一致）。
+    let payments = [
+        Payment(name: "規劃1", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(320000))], caseName: "誠鋼實業股份有限公司"),
+        Payment(name: "規劃1", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(120000))], caseName: "東經投資有限公司"),
+    ]
+    let rendered = ReplyFormPaymentBlock(payments: payments).render()
+
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">誠鋼實業股份有限公司</b>"))
+    #expect(rendered.contains("<b style=\"font-size: 1.1em;\">東經投資有限公司</b>"))
+    #expect(!rendered.contains("規劃1"), "單一 bundle 的 case 不應顯示 bundle 名")
+}
+
+@Test("reply form: bundle names shown only for cases with ≥2 bundles, order-independent")
+func replyFormPaymentBlockCountsBundlesPerCaseRegardlessOfOrder() {
+    // 甲公司的兩個 bundle 被乙公司隔開（非連續）→ 仍視為「甲有 2 bundle」照顯示；乙單 bundle 隱藏。
+    let payments = [
+        Payment(name: "規劃1", items: [.init(names: ["稅務帳務處理作業"], fee: .monthly(4000))], caseName: "甲公司"),
+        Payment(name: "乙方案", items: [.init(names: ["財務報表查核簽證"], fee: .yearly(50000))], caseName: "乙公司"),
+        Payment(name: "規劃2", items: [.init(names: ["記帳作業"], fee: .monthly(3000))], caseName: "甲公司"),
+    ]
+    let rendered = ReplyFormPaymentBlock(payments: payments).render()
+
+    #expect(rendered.contains("<b>規劃1</b>"))
+    #expect(rendered.contains("<b>規劃2</b>"))
+    #expect(!rendered.contains("乙方案"), "單一 bundle 的 case 不應顯示 bundle 名")
+}
+
+@Test("reply form: single case keeps existing single/multi bundle behavior")
+func replyFormPaymentBlockSingleCaseBehaviorUnchanged() {
+    // 單一 case、多 bundle → bundle 名照顯示、無 case 標題。
+    let multi = ReplyFormPaymentBlock(payments: [
+        Payment(name: "規劃1", items: [.init(names: ["A"], fee: .monthly(4000))], caseName: "甲公司"),
+        Payment(name: "規劃2", items: [.init(names: ["B"], fee: .yearly(50000))], caseName: "甲公司"),
+    ]).render()
+    #expect(!multi.contains("甲公司"), "單一 case 不應出現 case 名稱標題")
+    #expect(multi.contains("<b>規劃1</b>"))
+    #expect(multi.contains("<b>規劃2</b>"))
+
+    // 單一 case、單 bundle → bundle 名隱藏（既有行為）。
+    let single = ReplyFormPaymentBlock(payments: [
+        Payment(name: "規劃1", items: [.init(names: ["A"], fee: .monthly(4000))], caseName: nil),
+    ]).render()
+    #expect(!single.contains("規劃1"), "單 bundle 不應顯示 bundle 名")
+}
+
 
 
 


### PR DESCRIPTION
## 問題

使用者回報：多公司集團情況下，各公司規劃只有一個時，同意函仍顯示「規劃1」標題。

## 根因

- 報價單主酬金 `PaymentBlock` 已是 per-case 判斷：case 總共只有 1 個 bundle 就隱藏 bundle 名。
- 同意函 `ReplyFormPaymentBlock` 仍是舊的全域判斷（`payments.count == 1` 才隱藏）；多公司時 payments ≥ 2，故各公司的「規劃1」照顯示。

## 修正

- `PaymentCaseGrouping` 新增共用 `hidingSingleBundleNames(_:)`：以 per-caseName 的 bundle **總數**（非連續 run 數，順序無關）決定是否隱藏 bundle 名。
- `ReplyFormPaymentBlock.init` 改用共用規則，取代全域 count 判斷。
- `PaymentBlock.init` 原 inline 邏輯改呼叫共用方法，兩處行為一致。

## 測試

- 新增失敗測試重現 bug：兩 case 各 1 bundle → case 標題照顯示、規劃名隱藏。
- 補「≥2 bundle 的 case 照顯示、順序無關」與「單一 case 單/多 bundle 行為不變」回歸測試。
- `swift test` 全套 52 測試通過、0 failures。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化付款信息展示逻辑：按付款案例分别判断套餐数量。
  * 单个案例仅包含一个套餐时隐藏套餐名称；包含多个套餐时显示名称。
  * 多案例场景下的付款信息展示更加准确一致。

* **测试**
  * 新增多案例、单套餐和多套餐场景的覆盖，确保现有单案例行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->