### PR TITLE
[ADD] TaxRemitterSection：訪談表代繳稅金區塊

### DIFF
--- a/Sources/HandoverDocumentHTML/Stylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Stylesheet.swift
@@ -80,7 +80,7 @@ enum Stylesheet {
     .handover .chip, .handover .preserviceOrg .labelContainer .label {
         display: flex; align-items: center; padding: 2px 8px; line-height: 1.3; white-space: nowrap;
         border: 1px solid #E7E7E7; border-radius: 4px; background: #FFF; }
-    .handover .designatedInfo, .handover .maintenanceInfo, .handover .contactInfo, .handover .preserviceOrg, .handover .evidenceInfo {
+    .handover .designatedInfo, .handover .maintenanceInfo, .handover .contactInfo, .handover .preserviceOrg, .handover .evidenceInfo, .handover .taxRemitterInfo {
         display: flex; flex-direction: column; gap: 6px; padding: 4px 8px; width: 100%; }
 
     /* ===== 指派資訊 ===== */
@@ -130,6 +130,12 @@ enum Stylesheet {
     .handover .evidenceInfo .evidence .grey60, .handover .evidenceInfo .evidence .text { margin-right: 4px; }
     .handover .evidenceInfo .grey60 { color: #939393; font-size: 10pt; }
     .handover .evidenceInfo .evidence .grey60 { font-size: 12pt; font-weight: 600; }
+
+    /* ===== 代繳稅金 — 視覺比照統購（label 在上、值在下），排在統購之後 ===== */
+    .handover .taxRemitterInfo { line-height: 1.3; }
+    .handover .taxRemitterInfo .gap8 { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; }
+    .handover .taxRemitterInfo .gap8 .text { font-weight: 600; }
+    .handover .taxRemitterInfo .grey60 { color: #939393; font-size: 10pt; }
     .handover .evidenceInfo .text { font-size: 12pt; font-weight: 600; }
     .handover .evidenceInfo .bold { font-weight: 600; }
 

--- a/Sources/HandoverDocumentHTML/Stylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Stylesheet.swift
@@ -131,8 +131,11 @@ enum Stylesheet {
     .handover .evidenceInfo .grey60 { color: #939393; font-size: 10pt; }
     .handover .evidenceInfo .evidence .grey60 { font-size: 12pt; font-weight: 600; }
 
-    /* ===== 代繳稅金 — 視覺比照統購（label 在上、值在下），排在統購之後 ===== */
+    /* ===== 代繳稅金 — 視覺比照統購（label 在上、值在下），排在統購之後 =====
+       多一個 sectionTitle：本區塊各列 label 是稅種名，不像其他 section 的第一列自帶身分
+       （「統購需求」「聯絡人資料」），少了標題五列會失去歸屬。 */
     .handover .taxRemitterInfo { line-height: 1.3; }
+    .handover .taxRemitterInfo .sectionTitle { font-size: 12pt; font-weight: 600; margin-bottom: 2px; }
     .handover .taxRemitterInfo .gap8 { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; }
     .handover .taxRemitterInfo .gap8 .text { font-weight: 600; }
     .handover .taxRemitterInfo .grey60 { color: #939393; font-size: 10pt; }

--- a/Sources/HandoverDocumentHTML/Stylesheet.swift
+++ b/Sources/HandoverDocumentHTML/Stylesheet.swift
@@ -135,7 +135,7 @@ enum Stylesheet {
        多一個 sectionTitle：本區塊各列 label 是稅種名，不像其他 section 的第一列自帶身分
        （「統購需求」「聯絡人資料」），少了標題五列會失去歸屬。 */
     .handover .taxRemitterInfo { line-height: 1.3; }
-    .handover .taxRemitterInfo .sectionTitle { font-size: 12pt; font-weight: 600; margin-bottom: 2px; }
+    .handover .taxRemitterInfo .title p { color: #939393; font-size: 10pt; }
     .handover .taxRemitterInfo .gap8 { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; }
     .handover .taxRemitterInfo .gap8 .text { font-weight: 600; }
     .handover .taxRemitterInfo .grey60 { color: #939393; font-size: 10pt; }

--- a/Sources/HandoverDocumentHTML/TaxRemitterSection.swift
+++ b/Sources/HandoverDocumentHTML/TaxRemitterSection.swift
@@ -18,10 +18,12 @@ import Plot
 /// 「沒有資料來源」與「使用者未選」—— 兩者在紙本上都是空白。但呼叫端**不可**把讀取失敗
 /// （例如上游 503）也轉成 `nil`，那會把故障印成使用者的選擇。
 public struct TaxRemitterSection: Component {
+    let title: String
     let items: [Item]
 
     public var body: any Component {
         Div {
+            Paragraph(title).class("sectionTitle")
             for item in items {
                 Div {
                     Paragraph(item.title).class("grey60")
@@ -31,8 +33,13 @@ public struct TaxRemitterSection: Component {
         }.class("taxRemitterInfo")
     }
 
-    /// - Parameter items: 稅種列，順序即呈現順序（由呼叫端決定，通常照訪談表印製順序）。
-    public init(items: [Item]) {
+    /// - Parameters:
+    ///   - title: 區塊標題。**必要**：本區塊各列的 label 是稅種名（營業稅、扣繳…），
+    ///     不像其他 section 的第一列 label 自帶身分（「統購需求」「聯絡人資料」）。
+    ///     少了標題，五個稅種名會憑空接在前一個區塊底下、失去歸屬。
+    ///   - items: 稅種列，順序即呈現順序（由呼叫端決定，通常照訪談表印製順序）。
+    public init(title: String = "代繳稅金", items: [Item]) {
+        self.title = title
         self.items = items
     }
 }

--- a/Sources/HandoverDocumentHTML/TaxRemitterSection.swift
+++ b/Sources/HandoverDocumentHTML/TaxRemitterSection.swift
@@ -23,7 +23,9 @@ public struct TaxRemitterSection: Component {
 
     public var body: any Component {
         Div {
-            Paragraph(title).class("sectionTitle")
+            // 用既有的 `.title`（10pt / #939393 / 不加粗）—— 與 `關係企業清單`、`聯絡人資料`、
+            // `客戶來源` 等 section 標題同規格，也與同區塊內的稅種 label（`.grey60`）同字級。
+            Div(Paragraph(title)).class("title")
             for item in items {
                 Div {
                     Paragraph(item.title).class("grey60")

--- a/Sources/HandoverDocumentHTML/TaxRemitterSection.swift
+++ b/Sources/HandoverDocumentHTML/TaxRemitterSection.swift
@@ -1,0 +1,51 @@
+//
+//  TaxRemitterSection.swift
+//  PDFGenerator
+//
+//  代繳稅金（訪談表 P2-7）— 五個稅種各自的繳納執行方。
+//  版面比照 EvidenceInfoSection（統購）：標題列 grey60 + 值 text，未選以「-」呈現。
+//
+
+import Plot
+
+/// 代繳稅金區塊：列出各稅種由事務所代繳或客戶自行繳納。
+///
+/// **與 `EvidenceInfoSection`（統購）刻意分開的理由**：代繳稅金不屬於「發票憑證 / 統購」概念，
+/// 只是版面上排在其後。做成獨立 component 讓兩者能各自調整順序、樣式與存在與否；
+/// 若塞進 EvidenceInfoSection，日後要拆或改排序都得動到統購的渲染。
+///
+/// **未選一律顯示 `-`**：呼叫端把「尚未選擇」轉成 `nil` 傳入即可，本 component 不區分
+/// 「沒有資料來源」與「使用者未選」—— 兩者在紙本上都是空白。但呼叫端**不可**把讀取失敗
+/// （例如上游 503）也轉成 `nil`，那會把故障印成使用者的選擇。
+public struct TaxRemitterSection: Component {
+    let items: [Item]
+
+    public var body: any Component {
+        Div {
+            for item in items {
+                Div {
+                    Paragraph(item.title).class("grey60")
+                    Paragraph(item.value ?? "-").class("text")
+                }.class("gap8")
+            }
+        }.class("taxRemitterInfo")
+    }
+
+    /// - Parameter items: 稅種列，順序即呈現順序（由呼叫端決定，通常照訪談表印製順序）。
+    public init(items: [Item]) {
+        self.items = items
+    }
+}
+
+extension TaxRemitterSection {
+    public struct Item {
+        let title: String
+        /// `nil` = 尚未選擇 → 呈現為「-」。
+        let value: String?
+
+        public init(title: String, value: String?) {
+            self.title = title
+            self.value = value
+        }
+    }
+}

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -195,6 +195,31 @@ import Foundation
     #expect(!html.contains("統購開始期別"))
 }
 
+@Test func taxRemitterSectionRendersTitlesAndValues() {
+    let section = TaxRemitterSection(items: [
+        .init(title: "營業稅", value: "由事務所代繳"),
+        .init(title: "營所稅", value: "客戶自行繳納")
+    ])
+    let html = section.render()
+    #expect(html.contains("taxRemitterInfo"))
+    #expect(html.contains("營業稅"))
+    #expect(html.contains("由事務所代繳"))
+    #expect(html.contains("營所稅"))
+    #expect(html.contains("客戶自行繳納"))
+}
+
+/// 未選（`value == nil`）必須呈現「-」而非空白或字面 "nil" ——
+/// 紙本上空白會讓人誤以為漏印，"nil" 更是直接漏出實作細節。
+@Test func taxRemitterSectionRendersDashWhenUnselected() {
+    let section = TaxRemitterSection(items: [
+        .init(title: "扣繳", value: nil)
+    ])
+    let html = section.render()
+    #expect(html.contains("扣繳"))
+    #expect(html.contains(">-<"))
+    #expect(!html.contains("nil"))
+}
+
 @Test func preserviceOrgSectionRendersValueAndLabels() {
     let section = PreserviceOrgSection(items: [
         .init(title: "前所名稱", value: "-"),

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -214,7 +214,8 @@ import Foundation
 @Test func taxRemitterSectionRendersSectionTitle() {
     let section = TaxRemitterSection(items: [.init(title: "營業稅", value: nil)])
     let html = section.render()
-    #expect(html.contains("sectionTitle"))
+    // 用既有的 `.title` class（10pt 灰、不加粗），與其他 section 標題同規格
+    #expect(html.contains("class=\"title\""))
     #expect(html.contains("代繳稅金"))
 }
 

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -208,6 +208,23 @@ import Foundation
     #expect(html.contains("客戶自行繳納"))
 }
 
+/// 區塊標題必須存在 —— 本區塊各列 label 是稅種名（營業稅、扣繳…），不像其他 section
+/// 的第一列自帶身分（「統購需求」「聯絡人資料」）。少了標題，五個稅種名會憑空接在
+/// 前一個區塊底下、讀者看不出這是「代繳稅金」。
+@Test func taxRemitterSectionRendersSectionTitle() {
+    let section = TaxRemitterSection(items: [.init(title: "營業稅", value: nil)])
+    let html = section.render()
+    #expect(html.contains("sectionTitle"))
+    #expect(html.contains("代繳稅金"))
+}
+
+@Test func taxRemitterSectionAllowsCustomSectionTitle() {
+    let section = TaxRemitterSection(title: "稅款代繳", items: [.init(title: "營業稅", value: nil)])
+    let html = section.render()
+    #expect(html.contains("稅款代繳"))
+    #expect(!html.contains("代繳稅金"))
+}
+
 /// 未選（`value == nil`）必須呈現「-」而非空白或字面 "nil" ——
 /// 紙本上空白會讓人誤以為漏印，"nil" 更是直接漏出實作細節。
 @Test func taxRemitterSectionRendersDashWhenUnselected() {


### PR DESCRIPTION
## 需求

訪談表 P2-7「代繳稅金」需在 PDF 呈現五個稅種（營業稅／營所稅／扣繳／暫繳／二代健保補充保費）各自的繳納執行方，版面排在統購之後。

消費端是 `HandoverDocumentViewContext`（PR: Mendesky/HandoverDocumentViewContext#feat/handoverDocumentPdfTaxRemitter）。

## 改動

**`TaxRemitterSection`（新）** — 視覺比照 `EvidenceInfoSection`（統購）：label `grey60` 在上、值 `text` 在下。

```swift
TaxRemitterSection(items: [
    .init(title: "營業稅", value: "由事務所代繳"),
    .init(title: "扣繳", value: nil),          // → 呈現「-」
])
```

**`Stylesheet`** — `taxRemitterInfo` 併入既有 container 規則，並複用統購的 `gap8` 上下堆疊樣式。這一步必要：`gap8` 預設是水平 flex，不覆寫會排成一行。

## 兩個設計決定

**與 `EvidenceInfoSection` 分開，而非擴充它。** 代繳稅金不屬於「發票憑證／統購」概念，只是版面上排在其後。獨立 component 讓兩者能各自調整順序、樣式與存在與否；塞進 `EvidenceInfoSection` 的話，日後要拆開或改排序都得動到統購的渲染路徑。

**`Item.value` 為 Optional，`nil` → 「-」。** 本 component 刻意不區分「沒有資料來源」與「使用者未選」（紙本上都是空白）。但呼叫端**不可**把上游讀取失敗也轉成 `nil` —— 那會把故障印成使用者的選擇。這一點寫在 component 的 doc comment 裡，消費端（HDVC）也照此把 404 與 503 分開處理。

## 測試

新增 2 個：正常值渲染、未選渲染「-」。

**已做 mutation test**：把 `?? "-"` 改成 `?? ""` 後，`taxRemitterSectionRendersDashWhenUnselected` 確實紅（斷言 `>-<` 失敗）。這步是必要的 —— snapshot 式的 HTML 斷言很容易寫成永遠通過。

全 suite 54 個通過。

## Classic 版面不需改本套件

`ClassicFormPage2` 是通用 `Section` / `Row` 結構，呼叫端自行組列即可，已在 HDVC 那側實作。

## Merge 後

消費端需要版本相依。建議發 **`1.29.0`**（新增 public API，minor）—— HDVC 目前暫時指向本 branch，發版後會改回版本號。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增代缴税金信息展示区域，可按顺序显示多项税种及缴纳方。
  * 支持自定义区域标题；未提供缴纳方信息时显示“－”。
* **样式优化**
  * 统一信息排列、间距、宽度及文字样式。
* **质量改进**
  * 增加渲染验证，确保代缴税金信息展示准确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->