### PR TITLE
[FIX] classic 第 2 頁 label 欄支援 \n 換行

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage2.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage2.swift
@@ -83,13 +83,13 @@ public struct ClassicFormPage2: Component {
         switch row.kind {
         case .field:
             return [ComponentGroup {
-                TableCell(Text(row.label ?? "")).class("fieldLabel")
+                multilineCell(row.label ?? "").class("fieldLabel")
                 multilineCell(row.value).class("fieldValue").attribute(named: "colspan", value: "3")
             }]
         case .markdown:
             // 值為 markdown 原文，渲染成 HTML 後注入（標題/清單/粗體/inline <span> 等）。
             return [ComponentGroup {
-                TableCell(Text(row.label ?? "")).class("fieldLabel")
+                multilineCell(row.label ?? "").class("fieldLabel")
                 TableCell(Div(html: MarkdownHTML.render(row.value))).class("fieldValue").attribute(named: "colspan", value: "3")
             }]
         case .heading:
@@ -139,7 +139,9 @@ public struct ClassicFormPage2: Component {
         return out
     }
 
-    /// 值可含 \n，逐行以 <br> 斷開。
+    /// 值可含 \n，逐行以 <br> 斷開。label 亦沿用：label 欄寬固定（classicForm2 為 110px）且
+    /// CJK 可任意斷行，長標籤會落在不自然的位置（如「二代健保補充保」/「費」）。斷在哪屬領域
+    /// 語意，由呼叫端在字串中以 \n 指定；不含 \n 時渲染結果與先前完全相同。
     private func multilineCell(_ value: String) -> Component {
         let lines = value.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
         return TableCell {


### PR DESCRIPTION
## 問題

classic 第 2 頁的 label 欄寬固定（`classicForm2` 為 110px）且 CJK 可任意斷行，長標籤會斷在不自然的位置。實際案例是訪談表「代繳稅金」的「二代健保補充保費」：

```
二代健保補充保
費
```

末行只剩一個字，視覺上不美觀。

## 做法

值的儲存格原本就以 `multilineCell` 支援 `\n` → `<br>`，label 改為沿用同一個 helper：

```diff
- TableCell(Text(row.label ?? "")).class("fieldLabel")
+ multilineCell(row.label ?? "").class("fieldLabel")
```

`.field` 與 `.markdown` 兩種列的 label 皆套用，行為一致。

斷在哪裡屬於領域語意，由呼叫端在字串中以 `\n` 指定 —— PDFGenerator 作為框架不處理領域語意，不該知道「二代健保補充保費」該怎麼斷。

## 相容性

**不含 `\n` 的 label 渲染結果與先前完全相同**，既有版面零影響。

## 驗證

- PDFGenerator 56 個測試通過
- 於 HandoverDocumentViewContext 以本機路徑相依產出真實 PDF，抽取文字對照：

```
修改前：  二代健保補充保 / 費
修改後：  二代健保 / 補充保費
```

- 整份 PDF 文字做 diff，只有上述 4 行變化，其他 label（統購、前手、報價…）皆未受影響

## 後續

需發版（建議 **1.28.13**）後，HandoverDocumentViewContext 才能把該 label 改為 `"二代健保\n補充保費"` 並將相依下限提到 1.28.13。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 表单页面中的字段和 Markdown 行标签现支持自动换行，较长标签可完整显示。
  - 标签可通过预设换行位置进行断行，提升复杂内容下的可读性。
  - 标签布局保持固定宽度，页面整体排版更加稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->