### PR TITLE
[UPDATE] 訪談表備註區新增電子發票服務平台一行

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1+Model.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1+Model.swift
@@ -68,9 +68,34 @@ extension ClassicFormPage1 {
         public var cashierFee: String?
         public var nhiFee: String?
 
+        /// 備註區的「電子發票服務平台」一行。四個欄位皆為選填，未填時標籤後留白。
+        ///
+        /// 整體為 optional：未使用電子發票（或未填答）時呼叫端傳 `nil`，該行不印，
+        /// 避免在表單上留下一排空標籤。
+        public struct EinvoicePlatform {
+            public var account: String?
+            /// 密碼**明文**。目前無權限管控，一律印出（見設計 spec 2.6）。
+            public var password: String?
+            public var trackNumberStart: String?
+            public var trackNumberEnd: String?
+
+            public init(
+                account: String? = nil,
+                password: String? = nil,
+                trackNumberStart: String? = nil,
+                trackNumberEnd: String? = nil
+            ) {
+                self.account = account
+                self.password = password
+                self.trackNumberStart = trackNumberStart
+                self.trackNumberEnd = trackNumberEnd
+            }
+        }
+
         // 備註
         public var serviceGroup: String?
         public var serviceStartDate: String?
+        public var einvoicePlatform: EinvoicePlatform?
 
         public init(
             contactDate: String? = nil,
@@ -109,7 +134,8 @@ extension ClassicFormPage1 {
             cashierFee: String? = nil,
             nhiFee: String? = nil,
             serviceGroup: String? = nil,
-            serviceStartDate: String? = nil
+            serviceStartDate: String? = nil,
+            einvoicePlatform: EinvoicePlatform? = nil
         ) {
             self.contactDate = contactDate
             self.confirmDate = confirmDate
@@ -148,6 +174,7 @@ extension ClassicFormPage1 {
             self.nhiFee = nhiFee
             self.serviceGroup = serviceGroup
             self.serviceStartDate = serviceStartDate
+            self.einvoicePlatform = einvoicePlatform
         }
     }
 }

--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
@@ -151,6 +151,15 @@ public struct ClassicFormPage1: Component {
                 Span("發票明細：")
                 ClassicCheckboxGroup(items: model.invoiceChoices)
             }.class("invoiceLine")
+            // 未使用電子發票（或未填答）時整行不印——留一排空標籤只是噪音
+            if let platform = model.einvoicePlatform {
+                Paragraph(
+                    "電子發票服務平台："
+                    + "帳號：\(platform.account ?? "")　"
+                    + "密碼：\(platform.password ?? "")　"
+                    + "發票號碼起訖：\(platform.trackNumberStart ?? "") ~ \(platform.trackNumberEnd ?? "")"
+                )
+            }
             Paragraph("開始服務時間：\(model.serviceStartDate ?? "")")
         }.class("remarkBlock")
     }

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -424,3 +424,60 @@ import Foundation
     #expect(html.contains("第二段"))
     #expect(html.contains("<br"))
 }
+
+// MARK: 備註區的電子發票整合服務平台
+//
+// 印在「發票明細」勾選列下方，一行帶出帳號 / 密碼 / 字軌起訖。
+// 未使用電子發票（或未填答）時呼叫端傳 nil，整行不印——避免留下一排空標籤。
+
+@Test func classicFormPage1RendersEinvoicePlatformLineBelowInvoiceChoices() {
+    let page = ClassicFormPage1(model: .init(
+        companyName: "範例股份有限公司",
+        invoiceChoices: [("電子發票", true), ("二聯(副)", false)],
+        einvoicePlatform: .init(
+            account: "einvoice-user",
+            password: "p@ssw0rd",
+            trackNumberStart: "AB12345678",
+            trackNumberEnd: "CD12345700"
+        )
+    ))
+    let html = page.render()
+
+    #expect(html.contains("電子發票服務平台"))
+    #expect(html.contains("einvoice-user"))
+    #expect(html.contains("p@ssw0rd"))
+    #expect(html.contains("AB12345678"))
+    #expect(html.contains("CD12345700"))
+    // 位置：發票明細列之後
+    guard let invoiceIndex = html.range(of: "發票明細")?.lowerBound,
+          let platformIndex = html.range(of: "電子發票服務平台")?.lowerBound else {
+        Issue.record("兩個區塊都應存在")
+        return
+    }
+    #expect(invoiceIndex < platformIndex)
+}
+
+@Test func classicFormPage1OmitsEinvoicePlatformLineWhenAbsent() {
+    let page = ClassicFormPage1(model: .init(
+        companyName: "範例股份有限公司",
+        invoiceChoices: [("電子發票", false)]
+    ))
+    let html = page.render()
+
+    #expect(!html.contains("電子發票服務平台"))
+    #expect(html.contains("發票明細"))
+}
+
+// 四個欄位皆為選填：有平台但欄位未填時仍印出該行（標籤後留白），
+// 與同區塊的「服務組別」「開始服務時間」一致。
+@Test func classicFormPage1RendersEinvoicePlatformLineWithEmptyFields() {
+    let page = ClassicFormPage1(model: .init(
+        companyName: "範例股份有限公司",
+        einvoicePlatform: .init()
+    ))
+    let html = page.render()
+
+    #expect(html.contains("電子發票服務平台"))
+    #expect(html.contains("帳號"))
+    #expect(html.contains("發票號碼起訖"))
+}


### PR DESCRIPTION
## Summary
- classic 訪談表第 1 頁備註區，在「發票明細」勾選列下方新增「電子發票服務平台」一行，帶出帳號 / 密碼 / 發票號碼起訖
- 新增 `ClassicFormPage1.Model.EinvoicePlatform`（四個欄位皆選填），整組為 optional：呼叫端傳 `nil` 時該行不印，避免表單上留一排空標籤
- 有平台但個別欄位未填則標籤後留白，與同區塊「服務組別」「開始服務時間」行為一致

## Commits
- [UPDATE] 訪談表備註區新增電子發票服務平台一行

## Test plan
- [ ] 尚未於本次 session 執行測試（commit 內已附 `HandoverDocumentHTMLTests` 相關案例，待跑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持在经典表单中填写并展示电子发票服务平台账号、密码及发票号码起讫信息。
  - 电子发票平台信息可选配置，未提供时不会显示相关内容。
  - 即使部分平台字段为空，仍会保留平台信息及对应字段标签。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->