### PR TITLE
訪談表不印電子發票平台密碼明文，改印遮罩與查看指引

### DIFF
--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1+Model.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1+Model.swift
@@ -74,19 +74,23 @@ extension ClassicFormPage1 {
         /// 避免在表單上留下一排空標籤。
         public struct EinvoicePlatform {
             public var account: String?
-            /// 密碼**明文**。目前無權限管控，一律印出（見設計 spec 2.6）。
-            public var password: String?
+            /// 密碼**是否已設定**，不是密碼本身。
+            ///
+            /// 刻意收 `Bool` 而非 `String?`：紙本不印客戶密碼，只印遮罩與查看指引。
+            /// 型別上不接受明文，呼叫端就無從「不小心」把密碼傳進來 ——
+            /// 這比在呼叫端自律更可靠。已設定時的顯示字串由本套件負責（見 `ClassicFormPage1`）。
+            public var passwordIsSet: Bool
             public var trackNumberStart: String?
             public var trackNumberEnd: String?
 
             public init(
                 account: String? = nil,
-                password: String? = nil,
+                passwordIsSet: Bool = false,
                 trackNumberStart: String? = nil,
                 trackNumberEnd: String? = nil
             ) {
                 self.account = account
-                self.password = password
+                self.passwordIsSet = passwordIsSet
                 self.trackNumberStart = trackNumberStart
                 self.trackNumberEnd = trackNumberEnd
             }

--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
@@ -153,16 +153,63 @@ public struct ClassicFormPage1: Component {
             }.class("invoiceLine")
             // 未使用電子發票（或未填答）時整行不印——留一排空標籤只是噪音
             if let platform = model.einvoicePlatform {
-                Paragraph(
-                    "電子發票服務平台："
-                    + "帳號：\(platform.account ?? "")　"
-                    // 密碼不印明文：已設定印遮罩＋查看指引，未設定比照同行其他欄位留白。
-                    + "密碼：\(platform.passwordIsSet ? "●●●●●（請上嘉威平台查看）" : "")　"
-                    + "發票號碼起訖：\(platform.trackNumberStart ?? "") ~ \(platform.trackNumberEnd ?? "")"
-                )
+                let lines = Self.einvoicePlatformLines(platform)
+                Paragraph {
+                    for (index, line) in lines.enumerated() {
+                        if index < lines.count - 1 {
+                            Text(line).addLineBreak()
+                        } else {
+                            Text(line)
+                        }
+                    }
+                }
             }
             Paragraph("開始服務時間：\(model.serviceStartDate ?? "")")
         }.class("remarkBlock")
+    }
+
+    /// 電子發票服務平台的一到兩行。
+    ///
+    /// **起訖換到下一行的條件：帳號或密碼有值，且起訖有值。** 其餘情況維持單行 ——
+    /// 起訖沒值就換行會多出一行只寫著「發票號碼起訖：-」；帳號密碼都沒值時整行很短，
+    /// 不需要斷。斷點取在欄位邊界，避免整行過長時自動折在欄位中間。
+    private static func einvoicePlatformLines(_ platform: Model.EinvoicePlatform) -> [String] {
+        // 密碼不印明文：已設定印遮罩＋查看指引，未設定印 "-"。
+        let credentials = "帳號：\(fieldText(platform.account))　"
+            + "密碼：\(platform.passwordIsSet ? "●●●●●（請上嘉威平台查看）" : "-")"
+        let range = "發票號碼起訖：\(trackNumberRangeText(platform))"
+
+        let hasCredentials = hasValue(platform.account) || platform.passwordIsSet
+        let hasRange = hasValue(platform.trackNumberStart) || hasValue(platform.trackNumberEnd)
+        guard hasCredentials, hasRange else {
+            return ["電子發票服務平台：" + credentials + "　" + range]
+        }
+        return ["電子發票服務平台：" + credentials, range]
+    }
+
+    /// 字軌起訖的呈現。空值一律 `-`（對齊檢視頁與 page2 各欄位列的慣例）。
+    ///
+    /// 起訖是一組語意整體，兩邊都沒有時收成**單一** `-`，不印 `- ~ -` ——
+    /// 後者容易被讀成「有一個範圍，只是兩端沒填」。
+    ///
+    /// 單邊有值在寫入端是不可能的（同時給值或同時清空，違反回 `invalidEinvoiceTrackNumber`），
+    /// 此處仍逐邊 fallback，純粹是不讓呈現層對上游 invariant 做假設。
+    private static func trackNumberRangeText(
+        _ platform: Model.EinvoicePlatform
+    ) -> String {
+        guard hasValue(platform.trackNumberStart) || hasValue(platform.trackNumberEnd) else { return "-" }
+        return "\(fieldText(platform.trackNumberStart)) ~ \(fieldText(platform.trackNumberEnd))"
+    }
+
+    /// 欄位值的呈現：沒有值（nil 或只有空白）→ `-`。
+    /// 與檢視頁 `view-tab3` 的 `display()` 同一套判斷，含 trim。
+    private static func fieldText(_ value: String?) -> String {
+        hasValue(value) ? (value ?? "-") : "-"
+    }
+
+    private static func hasValue(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return value.contains { !$0.isWhitespace }
     }
 
     // MARK: helpers

--- a/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
+++ b/Sources/HandoverDocumentHTML/Classic/ClassicFormPage1.swift
@@ -156,7 +156,8 @@ public struct ClassicFormPage1: Component {
                 Paragraph(
                     "電子發票服務平台："
                     + "帳號：\(platform.account ?? "")　"
-                    + "密碼：\(platform.password ?? "")　"
+                    // 密碼不印明文：已設定印遮罩＋查看指引，未設定比照同行其他欄位留白。
+                    + "密碼：\(platform.passwordIsSet ? "●●●●●（請上嘉威平台查看）" : "")　"
                     + "發票號碼起訖：\(platform.trackNumberStart ?? "") ~ \(platform.trackNumberEnd ?? "")"
                 )
             }

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -427,8 +427,11 @@ import Foundation
 
 // MARK: 備註區的電子發票整合服務平台
 //
-// 印在「發票明細」勾選列下方，一行帶出帳號 / 密碼 / 字軌起訖。
+// 印在「發票明細」勾選列下方，一行帶出帳號 / 密碼狀態 / 字軌起訖。
 // 未使用電子發票（或未填答）時呼叫端傳 nil，整行不印——避免留下一排空標籤。
+//
+// **密碼不印明文**：model 只收 `passwordIsSet: Bool`，已設定時由本套件印遮罩與查看指引。
+// 型別上不接受 String，故「呼叫端不小心傳明文」在編譯期就不可能。
 
 @Test func classicFormPage1RendersEinvoicePlatformLineBelowInvoiceChoices() {
     let page = ClassicFormPage1(model: .init(
@@ -436,7 +439,7 @@ import Foundation
         invoiceChoices: [("電子發票", true), ("二聯(副)", false)],
         einvoicePlatform: .init(
             account: "einvoice-user",
-            password: "p@ssw0rd",
+            passwordIsSet: true,
             trackNumberStart: "AB12345678",
             trackNumberEnd: "CD12345700"
         )
@@ -445,7 +448,7 @@ import Foundation
 
     #expect(html.contains("電子發票服務平台"))
     #expect(html.contains("einvoice-user"))
-    #expect(html.contains("p@ssw0rd"))
+    #expect(html.contains("●●●●●（請上嘉威平台查看）"))
     #expect(html.contains("AB12345678"))
     #expect(html.contains("CD12345700"))
     // 位置：發票明細列之後
@@ -480,4 +483,19 @@ import Foundation
     #expect(html.contains("電子發票服務平台"))
     #expect(html.contains("帳號"))
     #expect(html.contains("發票號碼起訖"))
+}
+
+// 密碼未設定：標籤留白，比照同一行其他未填欄位；**不可**印遮罩，
+// 否則紙本會讓人以為客戶已經設過密碼。
+@Test func classicFormPage1LeavesEinvoicePasswordBlankWhenNotSet() {
+    let page = ClassicFormPage1(model: .init(
+        companyName: "範例股份有限公司",
+        einvoicePlatform: .init(account: "einvoice-user", passwordIsSet: false)
+    ))
+    let html = page.render()
+
+    #expect(html.contains("電子發票服務平台"))
+    #expect(html.contains("einvoice-user"))
+    #expect(html.contains("密碼"))
+    #expect(!html.contains("●"))
 }

--- a/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
+++ b/Tests/PDFGeneratorTests/HandoverDocumentHTMLTests.swift
@@ -451,6 +451,8 @@ import Foundation
     #expect(html.contains("●●●●●（請上嘉威平台查看）"))
     #expect(html.contains("AB12345678"))
     #expect(html.contains("CD12345700"))
+    // 帳密與起訖都有值 → 起訖斷到下一行（同一個 <p> 內以 <br> 斷，不多出段距）
+    #expect(html.contains("<br/>發票號碼起訖") || html.contains("<br>發票號碼起訖"))
     // 位置：發票明細列之後
     guard let invoiceIndex = html.range(of: "發票明細")?.lowerBound,
           let platformIndex = html.range(of: "電子發票服務平台")?.lowerBound else {
@@ -471,8 +473,10 @@ import Foundation
     #expect(html.contains("發票明細"))
 }
 
-// 四個欄位皆為選填：有平台但欄位未填時仍印出該行（標籤後留白），
-// 與同區塊的「服務組別」「開始服務時間」一致。
+// 四個欄位皆為選填：有平台但欄位未填時仍印出該行，各欄位印 `-`
+// （對齊檢視頁與 page2 各欄位列的慣例）。
+//
+// 起訖兩邊都沒有時收成**單一** `-`，不是 `- ~ -` —— 後者會被讀成「有範圍，只是兩端沒填」。
 @Test func classicFormPage1RendersEinvoicePlatformLineWithEmptyFields() {
     let page = ClassicFormPage1(model: .init(
         companyName: "範例股份有限公司",
@@ -481,13 +485,55 @@ import Foundation
     let html = page.render()
 
     #expect(html.contains("電子發票服務平台"))
-    #expect(html.contains("帳號"))
-    #expect(html.contains("發票號碼起訖"))
+    #expect(html.contains("帳號：-"))
+    #expect(html.contains("密碼：-"))
+    #expect(html.contains("發票號碼起訖：-"))
+    #expect(!html.contains("- ~ -"))
+    // 起訖沒值 → 不換行，免得多出一行只寫著「發票號碼起訖：-」
+    #expect(!html.contains("<br/>發票號碼起訖"))
+    #expect(!html.contains("<br>發票號碼起訖"))
 }
 
-// 密碼未設定：標籤留白，比照同一行其他未填欄位；**不可**印遮罩，
-// 否則紙本會讓人以為客戶已經設過密碼。
-@Test func classicFormPage1LeavesEinvoicePasswordBlankWhenNotSet() {
+// 只有起訖、帳密皆無 → 維持單行（整行很短，不需要斷）。
+@Test func classicFormPage1KeepsEinvoiceSingleLineWhenOnlyRangePresent() {
+    let page = ClassicFormPage1(model: .init(
+        companyName: "範例股份有限公司",
+        einvoicePlatform: .init(
+            account: nil,
+            passwordIsSet: false,
+            trackNumberStart: "AB12345678",
+            trackNumberEnd: "AB12345700"
+        )
+    ))
+    let html = page.render()
+
+    #expect(html.contains("帳號：-"))
+    #expect(html.contains("密碼：-"))
+    #expect(html.contains("AB12345678"))
+    #expect(!html.contains("<br/>發票號碼起訖"))
+    #expect(!html.contains("<br>發票號碼起訖"))
+}
+
+// 只有帳號（無密碼）+ 起訖 → 仍要換行。
+@Test func classicFormPage1BreaksEinvoiceRangeWhenOnlyAccountPresent() {
+    let page = ClassicFormPage1(model: .init(
+        companyName: "範例股份有限公司",
+        einvoicePlatform: .init(
+            account: "einvoice-user",
+            passwordIsSet: false,
+            trackNumberStart: "AB12345678",
+            trackNumberEnd: "AB12345700"
+        )
+    ))
+    let html = page.render()
+
+    #expect(html.contains("密碼：-"))
+    #expect(html.contains("<br/>發票號碼起訖") || html.contains("<br>發票號碼起訖"))
+}
+
+// 密碼未設定：印 "-"（對齊檢視頁 view-tab3 的 `passwordIsSet ? '••••••••' : '-'`）。
+// **不可**印遮罩，否則紙本會讓人以為客戶已經設過密碼。
+@Test func classicFormPage1MarksEinvoicePasswordAsAbsentWhenNotSet() {
     let page = ClassicFormPage1(model: .init(
         companyName: "範例股份有限公司",
         einvoicePlatform: .init(account: "einvoice-user", passwordIsSet: false)
@@ -496,6 +542,6 @@ import Foundation
 
     #expect(html.contains("電子發票服務平台"))
     #expect(html.contains("einvoice-user"))
-    #expect(html.contains("密碼"))
+    #expect(html.contains("密碼：-"))
     #expect(!html.contains("●"))
 }


### PR DESCRIPTION
## Summary

- 訪談表備註區「電子發票服務平台」那一行不再印密碼明文。model 的 `password: String?` 改為 `passwordIsSet: Bool`，已設定時印 `●●●●●（請上嘉威平台查看）`。**收 `Bool` 而非 String 是刻意的**：型別上不接受明文，呼叫端就無從不小心傳進來，比在呼叫端自律可靠。
- 空值呈現對齊檢視頁 `view-tab3` 的 `display()`：帳號 / 密碼 / 起訖沒填一律 `-`（判斷用 trim 後非空）。起訖兩端都沒有時收成**單一** `-`，不印 `- ~ -` —— 後者會被讀成「有範圍，只是兩端沒填」。
- 帳密與起訖都有值時把起訖斷到下一行（`<br>` 在同一個 `<p>` 內，沿用 `ClassicFormPage2` 的既有慣例，不用第二個 `<p>` 以免多出段距）。起訖沒值則不斷行，避免多出一行只寫著「發票號碼起訖：-」。

⚠️ **API breaking（對 package 消費端）**：`ClassicFormPage1.Model.EinvoicePlatform` 的 `password` 參數移除。唯一消費端是 HandoverDocumentViewContext（對應 PR 已開）。合併後需**發版**，該 repo 才能從本機路徑覆寫改回 git 相依。

## Commits

- [ADJUST] 訪談表不印電子發票平台密碼明文，改印遮罩與查看指引
- [ADJUST] 電子發票平台空值印 -，帳密與起訖過長時斷成兩行

## Test plan

- [x] `swift test --filter "Einvoice"` — 4 tests 通過（第一個 commit 後執行）
- [x] `swift build` — 第二個 commit 後 compile check 通過
- [ ] 第二個 commit（空值 `-` 與斷行）新增的三隻測試**尚未執行**，僅驗證可編譯
- [ ] 實機產出 PDF 確認版面（`●` 數量、括號文字是否擠到換行、第二行是否需要縮排對齊）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 电子发票平台信息中的密码改为遮罩显示，并提供查看提示，避免明文展示。
  * 未填写的账号、密码和发票字轨统一显示为“-”。
  * 平台信息与发票字轨将根据内容自动换行，并支持字轨范围格式化。
* **错误修复**
  * 优化空字段、未设置密码及部分字段填写时的显示效果，提升交接文件内容的准确性与一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->