### PR TITLE
[NEW] Added Teams CI notification

### DIFF
--- a/.github/workflows/swift-build-and-testing.yml
+++ b/.github/workflows/swift-build-and-testing.yml
@@ -42,3 +42,122 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ join(fromJSON(steps.coverage-files.outputs.files), ',') }}
+
+  # ────────────────────────────────────────────────────────────
+  # 通知：build 跑完後發 Teams Adaptive Card。
+  #   - always()：紅 / 綠 / skip / cancelled 都通知。
+  #   - 只有「失敗」時才 @tag 人；綠燈不吵人。
+  #   - build 被 concurrency 取消 → 視為中性（不誤報失敗）。
+  #
+  # 需要的設定：
+  #   secret  TEAMS_WEBHOOK_URL          — Power Automate Workflow 的觸發 URL
+  #   file    .github/workflows/teams-mapping.json — GitHub login → Teams 身分對照表
+  # ────────────────────────────────────────────────────────────
+  notify-teams:
+    name: Notify Teams
+    needs: [build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compose & send Adaptive Card
+        env:
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+
+          # 整體狀態
+          if [ "$BUILD_RESULT" = "failure" ]; then
+            overall="failure"; emoji="❌"; color="Attention"
+          elif [ "$BUILD_RESULT" = "cancelled" ]; then
+            overall="cancelled"; emoji="⚪"; color="Default"
+          else
+            overall="success"; emoji="✅"; color="Good"
+          fi
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          # PR 直連（PR 事件才有 .pull_request.number）
+          pr_number=$(jq -r '.pull_request.number // empty' "$GITHUB_EVENT_PATH")
+          pr_url=""
+          [ -n "$pr_number" ] && pr_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${pr_number}"
+
+          # 分支顯示
+          branch_name="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          branch_disp="$branch_name"
+          [ -n "$pr_number" ] && branch_disp="$branch_name (PR #$pr_number)"
+
+          # 解析要 tag 的人
+          MAP_FILE=.github/workflows/teams-mapping.json
+          people='[]'
+          if [ -f "$MAP_FILE" ]; then
+            people=$(jq -c --slurpfile map "$MAP_FILE" --arg status "$overall" '
+              ($map[0] | with_entries(.key |= ascii_downcase)) as $m
+              | ( if   $status == "success" then (.pull_request.requested_reviewers // [])
+                  elif $status == "failure" then (.pull_request.assignees // [])
+                  else [] end )
+              | map(.login | ascii_downcase) | unique
+              | map($m[.]) | map(select(. != null)) | unique_by(.upn)
+            ' "$GITHUB_EVENT_PATH")
+          fi
+
+          # debug
+          echo "::group::tag 對照 debug"
+          echo "event=$GITHUB_EVENT_NAME  overall=$overall"
+          if [ ! -f "$MAP_FILE" ]; then
+            echo "map 檔  : ✗ 不存在"
+          elif ! jq empty "$MAP_FILE" 2>/dev/null; then
+            echo "map 檔  : ⚠️ JSON 壞掉"
+          else
+            echo "map 檔  : ✓ 存在，共 $(jq 'length' "$MAP_FILE") 筆"
+          fi
+          echo "assignees          : $(jq -c '[(.pull_request.assignees // [])[].login]' "$GITHUB_EVENT_PATH")"
+          echo "requested_reviewers: $(jq -c '[(.pull_request.requested_reviewers // [])[].login]' "$GITHUB_EVENT_PATH")"
+          echo "→ 對到的人(已mapping): $people"
+          echo "::endgroup::"
+
+          entities=$(jq -nc --argjson p "$people" '
+            [ $p[] | {type:"mention", text:("<at>"+.name+"</at>"),
+                      mentioned:{id:.upn, name:.name}} ]')
+          mline=$(jq -rn --argjson p "$people" --arg status "$overall" '
+            if ($p|length)==0 then ""
+            else ($p | map("<at>"+.name+"</at>") | join(" ")) as $tags
+              | if   $status=="success" then "✅ CI 已通過，請 reviewer 協助 merge：" + $tags
+                elif $status=="failure" then "❌ CI 失敗，請 assignee 儘快 fix：" + $tags
+                else $tags end
+            end')
+
+          payload=$(jq -nc \
+            --arg title "$emoji CI $overall · $branch_disp" \
+            --arg color "$color" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg branch "$branch_disp" \
+            --arg br "$BUILD_RESULT" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg mline "$mline" \
+            --arg runurl "$run_url" \
+            --arg prurl "$pr_url" \
+            --argjson entities "$entities" '
+            {
+              type:"AdaptiveCard",
+              "$schema":"http://adaptivecards.io/schemas/adaptive-card.json",
+              version:"1.5",
+              body: ([
+                {type:"TextBlock", size:"Large", weight:"Bolder", color:$color, text:$title},
+                {type:"FactSet", facts:[
+                  {title:"Repo",   value:$repo},
+                  {title:"Branch", value:$branch},
+                  {title:"Build",  value:$br},
+                  {title:"By",     value:$actor}
+                ]}
+              ] + (if $mline=="" then [] else [{type:"TextBlock", wrap:true, text:$mline}] end)),
+              actions: (
+                (if $prurl=="" then [] else [{type:"Action.OpenUrl", title:"前往 PR（可直接 merge）", url:$prurl}] end)
+                + [{type:"Action.OpenUrl", title:"查看執行紀錄", url:$runurl}]
+              ),
+              msteams:{entities:$entities}
+            }')
+
+          curl -sSf -X POST -H "Content-Type: application/json" \
+            -d "$payload" "$TEAMS_WEBHOOK_URL"

--- a/.github/workflows/swift-build-and-testing.yml
+++ b/.github/workflows/swift-build-and-testing.yml
@@ -67,6 +67,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # secret 未設定 → 跳過通知（設定後自動生效），不讓 PR 因此紅燈
+          if [ -z "${TEAMS_WEBHOOK_URL:-}" ]; then
+            echo "::warning::TEAMS_WEBHOOK_URL secret 未設定 — 跳過 Teams 通知"
+            exit 0
+          fi
+
           # 整體狀態
           if [ "$BUILD_RESULT" = "failure" ]; then
             overall="failure"; emoji="❌"; color="Attention"

--- a/.github/workflows/teams-mapping.json
+++ b/.github/workflows/teams-mapping.json
@@ -1,0 +1,7 @@
+{
+  "gradyzhuo":     { "upn": "gradyzhuo@jwcpas.com.tw", "name": "Grady" },
+  "abner-tungchi": { "upn": "abnertsai@jwcpas.com.tw", "name": "Abner" },
+  "cattybaby723":  { "upn": "anrouhu@jwcpas.com.tw",   "name": "Anrou" },
+  "datouwangUI":   { "upn": "datouwang@jwcpas.com.tw", "name": "Datou" },
+  "suling0":       { "upn": "suling@jwcpas.com.tw",   "name": "Suling" }
+}


### PR DESCRIPTION
為本 repo 加上 Teams CI 通知機制（與 mendesky-web ci.yml 相同的 notify-teams job）：

- CI 跑完發 Adaptive Card 到 Teams 頻道：綠燈 tag reviewer 協助 merge、紅燈 tag assignee 儘快修
- tag 對照表：`.github/workflows/teams-mapping.json`（GitHub login → Teams UPN，新成員記得維護）
- ⚠️ 需在 repo Settings → Secrets 新增 `TEAMS_WEBHOOK_URL`（Power Automate 觸發 URL）通知才會送出；未設定前 notify job 會失敗，不影響 build

Reviewer 為隨機分配，順便同步這套機制 🙌