### PR TITLE
服務範圍：服務內容吃 markdown，並修正編號清單的縮排

### DIFF
--- a/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
+++ b/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
@@ -69,6 +69,12 @@ enum ServiceContentHTMLRenderer {
     .rich-serviceContent p,
     .rich-serviceContent ul,
     .rich-serviceContent ol { margin: 0; }
+    /* 多段落／段落與清單之間要有呼吸空間；單段落時不受影響（相鄰選擇器） */
+    .rich-serviceContent p + p,
+    .rich-serviceContent p + ul,
+    .rich-serviceContent p + ol,
+    .rich-serviceContent ul + p,
+    .rich-serviceContent ol + p { margin-top: 0.5em; }
     .rich-serviceContent ul,
     .rich-serviceContent ol { list-style-position: inside; padding-left: 0; text-indent: 0; }
     .rich-serviceContent li { text-indent: 0; }

--- a/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
+++ b/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
@@ -26,7 +26,10 @@ import Markdown
 ///   產生的標籤不含 sentinel，因此不受影響。markdown 語法字元（`-`、`*`、`#`）全程不動。
 /// - **soft break → `<br>`**：段落內單一 `\n` 轉硬換行。原本的 `Div(term)` 完全不處理 `\n`，
 ///   多行服務內容在 PDF 會連成一行；這裡一併修掉。
-/// - **scoped `<style>`**：`.rich-serviceContent` scope，並明確設定清單縮排，不吃瀏覽器預設。
+/// - **scoped `<style>`**：`.rich-serviceContent` scope，清單縮排明確指定、不吃 weasyprint 預設。
+///   `list-style-position: inside` + `padding-left: 0`：標記排在文字流內，左緣與其他段落對齊。
+///   用 `outside` + padding 會讓圓點凸出外層容器（外層已有 `padding-left: 3em` / `text-indent: 2em`），
+///   前端實測就是這個症狀，兩端必須採同一個決定，否則畫面對齊、印出來不對齊。
 enum ServiceContentHTMLRenderer {
 
     static func render(markdown: String) -> String {
@@ -67,7 +70,7 @@ enum ServiceContentHTMLRenderer {
     .rich-serviceContent ul,
     .rich-serviceContent ol { margin: 0; }
     .rich-serviceContent ul,
-    .rich-serviceContent ol { padding-left: 1.4em; text-indent: 0; }
+    .rich-serviceContent ol { list-style-position: inside; padding-left: 0; text-indent: 0; }
     .rich-serviceContent li { text-indent: 0; }
     </style>
     """

--- a/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
+++ b/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
@@ -1,0 +1,81 @@
+//
+//  ServiceContentHTMLRenderer.swift
+//  PDFGenerator
+//
+//  把服務範圍裡「服務內容」（自訂服務項目的自由文字）的 markdown 渲染成 PDF 用 HTML。
+//
+
+import Foundation
+import Markdown
+
+/// 服務內容（`QuotingServiceTerm.term`）的 markdown → HTML。
+///
+/// **為什麼不直接用 `SupplementaryNoteHTMLRenderer`**（酬金補充說明那支）：
+/// 1. 它的 scoped class 是 `.rich-supplementaryNote`，用在服務範圍語意錯位；
+/// 2. 它只把 `ul`/`ol` 的 `margin` 歸零、**沒有設 `padding-left`** —— 服務內容外層已有
+///    `padding-left: 3em` + `text-indent: 2em`，再吃 weasyprint 的清單預設縮排（約 40px）會歪掉；
+/// 3. **escape 行為必須相反**：那支刻意讓 raw HTML 透出（有測試明文鎖住，因為補充說明會嵌
+///    `<img data:...>`）；服務內容是使用者自由輸入、會印進報價單，不該能注入標記。
+///
+/// 渲染規則：
+/// - **以 sentinel 繞過 CommonMark 的 entity 解碼再轉實體**：`swift-markdown` 的
+///   `HTMLFormatter.visitText` 不做 escape（與 Plot 的 `text.escaped()` 相反），所以使用者打的
+///   `<script>` 會原樣進 HTML。但**不能先轉成 `&lt;` 再 parse** —— entity reference 是 CommonMark
+///   的合法語法，parser 會把 `&lt;` 解碼回 `<`，escape 等於白做（實測如此）。故先把三個字元換成
+///   Unicode 私用區 sentinel（對 markdown 而言就是普通文字），渲染完再換成實體；formatter 自己
+///   產生的標籤不含 sentinel，因此不受影響。markdown 語法字元（`-`、`*`、`#`）全程不動。
+/// - **soft break → `<br>`**：段落內單一 `\n` 轉硬換行。原本的 `Div(term)` 完全不處理 `\n`，
+///   多行服務內容在 PDF 會連成一行；這裡一併修掉。
+/// - **scoped `<style>`**：`.rich-serviceContent` scope，並明確設定清單縮排，不吃瀏覽器預設。
+enum ServiceContentHTMLRenderer {
+
+    static func render(markdown: String) -> String {
+        let document = Document(parsing: shieldHTMLCharacters(markdown))
+        var rewriter = ServiceContentSoftBreakRewriter()
+        let rewritten = rewriter.visit(document) ?? document
+        let body = unshieldToEntities(HTMLFormatter.format(rewritten))
+        return scopedStyleBlock + "<div class=\"rich-serviceContent\">\(body)</div>"
+    }
+
+    // Unicode 私用區（U+E000–U+F8FF）：不會出現在正常輸入，markdown 視為普通文字。
+    private static let ampShield = "\u{E000}"
+    private static let ltShield = "\u{E001}"
+    private static let gtShield = "\u{E002}"
+
+    /// parse 前：把 HTML 特殊字元換成 sentinel，避開 CommonMark 的 entity 解碼。
+    static func shieldHTMLCharacters(_ raw: String) -> String {
+        raw
+            .replacingOccurrences(of: "&", with: ampShield)
+            .replacingOccurrences(of: "<", with: ltShield)
+            .replacingOccurrences(of: ">", with: gtShield)
+    }
+
+    /// 渲染後：sentinel → HTML 實體。此時 formatter 產生的標籤已就位，不會被誤傷。
+    static func unshieldToEntities(_ html: String) -> String {
+        html
+            .replacingOccurrences(of: ampShield, with: "&amp;")
+            .replacingOccurrences(of: ltShield, with: "&lt;")
+            .replacingOccurrences(of: gtShield, with: "&gt;")
+    }
+
+    /// 服務內容嵌在既有 `padding-left: 3em` / `text-indent: 2em` 的容器內：
+    /// block margin 歸零避免多餘上下留白，清單自帶縮排（不吃 weasyprint 預設的 40px），
+    /// 且 `text-indent: 0` 讓 `<li>` 不被外層的首行縮排推歪。
+    static let scopedStyleBlock: String = """
+    <style>
+    .rich-serviceContent p,
+    .rich-serviceContent ul,
+    .rich-serviceContent ol { margin: 0; }
+    .rich-serviceContent ul,
+    .rich-serviceContent ol { padding-left: 1.4em; text-indent: 0; }
+    .rich-serviceContent li { text-indent: 0; }
+    </style>
+    """
+}
+
+/// 段落內單一 `\n`（SoftBreak）→ `LineBreak`（`<br />`）。`\n\n` 是段落邊界、不受影響。
+private struct ServiceContentSoftBreakRewriter: MarkupRewriter {
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> Markup? {
+        LineBreak()
+    }
+}

--- a/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
+++ b/Sources/QuotationHTML/ServiceContentHTMLRenderer.swift
@@ -78,6 +78,13 @@ enum ServiceContentHTMLRenderer {
     .rich-serviceContent ul,
     .rich-serviceContent ol { list-style-position: inside; padding-left: 0; text-indent: 0; }
     .rich-serviceContent li { text-indent: 0; }
+    /* `swift-markdown` 的 HTMLFormatter 一律把 list item 內容包成 `<p>`（不分 tight/loose）。
+       `<p>` 是 block，而 `list-style-position: inside` 的標記是行內的 —— 標記會自己佔一個行框、
+       內容從下一行開始，實際 PDF 就是「•」與文字分成兩行。改成 inline 讓標記與首段同行。
+       （前端沒有這個症狀：markdown-it 對 tight list 不包 `<p>`。）
+       同 li 內的第二段以後仍要自己成段，否則多段會黏成一行。 */
+    .rich-serviceContent li > p { display: inline; }
+    .rich-serviceContent li > p + p { display: block; margin-top: 0.5em; }
     </style>
     """
 }

--- a/Sources/QuotationHTML/ServiceScope.swift
+++ b/Sources/QuotationHTML/ServiceScope.swift
@@ -27,7 +27,11 @@ public struct ServiceScope: Component {
                         Div(Text("（\(offset.representToChineseString(offset: 1))）\(item.title)")).style("display: flex; text-indent: 2em;")
                         Div{
                             if let term = item.term{
-                                Div(term).style("display: flex; padding-left: 3em; text-indent: 2em;")
+                                // 服務內容吃 markdown（項目符號清單 + 段落內換行）；escape 由 renderer 負責，
+                                // 見 ServiceContentHTMLRenderer。原本是 `Div(term)`：Plot 會 escape，
+                                // 但完全不處理 `\n`，多行內容在 PDF 會連成一行。
+                                Div(html: ServiceContentHTMLRenderer.render(markdown: term))
+                                    .style("display: flex; padding-left: 3em; text-indent: 2em;")
                             }
                         }.style("display: flex; flex-direction: column; padding-left: 2em;")
                         if let serviceItemTerms = item.serviceItemTerms{

--- a/Sources/QuotationHTML/ServiceScope.swift
+++ b/Sources/QuotationHTML/ServiceScope.swift
@@ -30,10 +30,14 @@ public struct ServiceScope: Component {
                                 // 服務內容吃 markdown（項目符號清單 + 段落內換行）；escape 由 renderer 負責，
                                 // 見 ServiceContentHTMLRenderer。原本是 `Div(term)`：Plot 會 escape，
                                 // 但完全不處理 `\n`，多行內容在 PDF 會連成一行。
+                                //
+                                // **無縮排**：原本是 `padding-left: 3em; text-indent: 2em`，疊上外層的 2em
+                                // 之後內文比標題深了三層，編號項又是另一個深度 —— 三層遞進縮排。使用者要求
+                                // 內文與編號項全部對齊同一條左緣（首行縮排由資料本身的全形空格表達，不由 CSS 加）。
                                 Div(html: ServiceContentHTMLRenderer.render(markdown: term))
-                                    .style("display: flex; padding-left: 3em; text-indent: 2em;")
+                                    .style("display: flex;")
                             }
-                        }.style("display: flex; flex-direction: column; padding-left: 2em;")
+                        }.style("display: flex; flex-direction: column;")
                         if let serviceItemTerms = item.serviceItemTerms{
                             Div{
                                 List{
@@ -44,8 +48,14 @@ public struct ServiceScope: Component {
                                             }
                                         }
                                     }
-                                }.environmentValue(.ordered, key: .listStyle)
-                            }.style("display: flex; padding-left: 3.8em;")
+                                }
+                                .environmentValue(.ordered, key: .listStyle)
+                                // `<ol>` 自身仍會吃瀏覽器／weasyprint 預設的 padding-left（約 40px），
+                                // 不關掉的話編號會比內文右一截。`inside` 讓「1.」排進文字流，與內文同左緣。
+                                .style("list-style-position: inside; padding-left: 0; margin: 0;")
+                                // 編號與內文共用同一條左緣：標記排進文字流（`inside`）、清單自身不再吃
+                                // 瀏覽器預設的 padding。原本外層還有 `padding-left: 3.8em`，是三層縮排的最後一層。
+                            }.style("display: flex;")
                         }
                     }.style("display: flex; flex-direction: column;  break-inside: avoid-page; ")
                 }

--- a/Sources/QuotationHTML/ServiceScope.swift
+++ b/Sources/QuotationHTML/ServiceScope.swift
@@ -52,7 +52,12 @@ public struct ServiceScope: Component {
                                 .environmentValue(.ordered, key: .listStyle)
                                 // `<ol>` 自身仍會吃瀏覽器／weasyprint 預設的 padding-left（約 40px），
                                 // 不關掉的話編號會比內文右一截。`inside` 讓「1.」排進文字流，與內文同左緣。
-                                .style("list-style-position: inside; padding-left: 0; margin: 0;")
+                                //
+                                // **margin 不歸零**：先前一併寫了 `margin: 0`，那超出「對齊」的需要——
+                                // 它拿掉的是 `<ol>` 預設的上下 margin，也就是「內文與第一個編號項之間」
+                                // 那道間距，結果整段看起來比原本更擠。行距本身沒動過（1.5em，
+                                // 設在 Quotation.swift 的根容器），變窄的是區塊間距。
+                                .style("list-style-position: inside; padding-left: 0;")
                                 // 編號與內文共用同一條左緣：外層用同一個 `bodyIndent`，清單自身不再吃
                                 // 瀏覽器預設的 padding（約 40px），標記 `inside` 排進文字流。
                             }.style("display: flex; padding-left: \(Self.bodyIndent);")
@@ -66,8 +71,10 @@ public struct ServiceScope: Component {
     /// 內文與編號項共用的縮排深度（相對於區塊左緣）。
     ///
     /// 兩者**必須用同一個值**——它們在版面上是同一層；分開寫就是先前「一層比一層右」的來源。
-    /// 標題（`（一）…`）自己用 `text-indent: 2em`，比這層淺一階。
-    static let bodyIndent = "4em"
+    ///
+    /// `5em` 是算出來的，不是估的：標題自己 `text-indent: 2em`，前綴「（一）」佔 3 個全形字（≈3em），
+    /// 所以標題第一個字（例：「稅務帳務處理作業」的「稅」）落在 5em —— 內文與編號項對齊到那裡。
+    static let bodyIndent = "5em"
 
     public init(title: String, heading: String, items: [QuotingServiceTerm]?) {
         self.index = -1

--- a/Sources/QuotationHTML/ServiceScope.swift
+++ b/Sources/QuotationHTML/ServiceScope.swift
@@ -31,13 +31,13 @@ public struct ServiceScope: Component {
                                 // 見 ServiceContentHTMLRenderer。原本是 `Div(term)`：Plot 會 escape，
                                 // 但完全不處理 `\n`，多行內容在 PDF 會連成一行。
                                 //
-                                // **無縮排**：原本是 `padding-left: 3em; text-indent: 2em`，疊上外層的 2em
-                                // 之後內文比標題深了三層，編號項又是另一個深度 —— 三層遞進縮排。使用者要求
-                                // 內文與編號項全部對齊同一條左緣（首行縮排由資料本身的全形空格表達，不由 CSS 加）。
+                                // 縮排只有一層：內文與編號項**共用** `Self.bodyIndent`，都縮在標題底下。
+                                // 原本是外層 2em ＋ 自身 3em ＋ text-indent 2em，而編號項另外 3.8em ——
+                                // 三個不同深度，一層比一層右。首行縮排由資料本身的全形空格表達，不由 CSS 加。
                                 Div(html: ServiceContentHTMLRenderer.render(markdown: term))
                                     .style("display: flex;")
                             }
-                        }.style("display: flex; flex-direction: column;")
+                        }.style("display: flex; flex-direction: column; padding-left: \(Self.bodyIndent);")
                         if let serviceItemTerms = item.serviceItemTerms{
                             Div{
                                 List{
@@ -53,9 +53,9 @@ public struct ServiceScope: Component {
                                 // `<ol>` 自身仍會吃瀏覽器／weasyprint 預設的 padding-left（約 40px），
                                 // 不關掉的話編號會比內文右一截。`inside` 讓「1.」排進文字流，與內文同左緣。
                                 .style("list-style-position: inside; padding-left: 0; margin: 0;")
-                                // 編號與內文共用同一條左緣：標記排進文字流（`inside`）、清單自身不再吃
-                                // 瀏覽器預設的 padding。原本外層還有 `padding-left: 3.8em`，是三層縮排的最後一層。
-                            }.style("display: flex;")
+                                // 編號與內文共用同一條左緣：外層用同一個 `bodyIndent`，清單自身不再吃
+                                // 瀏覽器預設的 padding（約 40px），標記 `inside` 排進文字流。
+                            }.style("display: flex; padding-left: \(Self.bodyIndent);")
                         }
                     }.style("display: flex; flex-direction: column;  break-inside: avoid-page; ")
                 }
@@ -63,6 +63,12 @@ public struct ServiceScope: Component {
         }
     }
     
+    /// 內文與編號項共用的縮排深度（相對於區塊左緣）。
+    ///
+    /// 兩者**必須用同一個值**——它們在版面上是同一層；分開寫就是先前「一層比一層右」的來源。
+    /// 標題（`（一）…`）自己用 `text-indent: 2em`，比這層淺一階。
+    static let bodyIndent = "4em"
+
     public init(title: String, heading: String, items: [QuotingServiceTerm]?) {
         self.index = -1
         self.title = title

--- a/Sources/QuotationHTML/ServiceScope.swift
+++ b/Sources/QuotationHTML/ServiceScope.swift
@@ -51,15 +51,22 @@ public struct ServiceScope: Component {
                                 }
                                 .environmentValue(.ordered, key: .listStyle)
                                 // `<ol>` 自身仍會吃瀏覽器／weasyprint 預設的 padding-left（約 40px），
-                                // 不關掉的話編號會比內文右一截。`inside` 讓「1.」排進文字流，與內文同左緣。
+                                // 不關掉的話編號會比內文右一截，所以 padding 要自己指定。
+                                //
+                                // **`outside` 而非 `inside`**：`inside` 把標記排進文字流，於是折行會回到
+                                // 標記的左緣、跟「1.」對齊，長項目讀起來像下一個項目的開頭。`outside` 讓標記
+                                // 落在 padding 區、文字自成一欄，折行自然縮在項目內（hanging indent）。
+                                //
+                                // `0.8em` = 標記欄寬。標記在該欄內靠右貼齊文字左緣，所以這個值同時決定
+                                // 「1.」的左緣落在哪：0.8em 讓它對齊上方內文的第一個字（實測標楷體 16px）。
+                                // 位數變多（「10.」）時標記往左長，文字欄不動 —— 這正是 `outside` 的好處，
+                                // 全部項目的文字左緣一致。
                                 //
                                 // **margin 不歸零**：先前一併寫了 `margin: 0`，那超出「對齊」的需要——
                                 // 它拿掉的是 `<ol>` 預設的上下 margin，也就是「內文與第一個編號項之間」
                                 // 那道間距，結果整段看起來比原本更擠。行距本身沒動過（1.5em，
                                 // 設在 Quotation.swift 的根容器），變窄的是區塊間距。
-                                .style("list-style-position: inside; padding-left: 0;")
-                                // 編號與內文共用同一條左緣：外層用同一個 `bodyIndent`，清單自身不再吃
-                                // 瀏覽器預設的 padding（約 40px），標記 `inside` 排進文字流。
+                                .style("list-style-position: outside; padding-left: 0.8em;")
                             }.style("display: flex; padding-left: \(Self.bodyIndent);")
                         }
                     }.style("display: flex; flex-direction: column;  break-inside: avoid-page; ")

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -81,6 +81,19 @@ import Foundation
 // 服務範圍原本是三層遞進縮排（標題 text-indent:2em → 內文 2em+3em+2em → 編號項 3.8em），
 // 一層比一層右。要求是內文與編號項**共用同一層縮排**（仍縮在標題底下，不是貼齊容器左緣）。
 // 這條鎖住「兩者深度相同」——分開寫就會重演遞進縮排，而版面問題不會有測試訊號。
+// `<ol>` 的上下 margin 不得歸零：它就是「內文與第一個編號項之間」那道間距。
+// 為了讓編號與內文同左緣只需要關掉 padding-left，一併寫 margin: 0 會讓整段比原本更擠
+// （行距本身是 Quotation.swift 根容器的 1.5em，與這裡無關）。
+@Test func serviceScopeKeepsListBlockSpacing() {
+    let model = QuotingServiceTerm.Model(
+        title: "標題", term: "內文", serviceItemTerms: [.init(content: "工作項目")]
+    )
+    let html = ServiceScope(index: 0, model: .init(title: "T", heading: "H", items: [model])).render()
+
+    #expect(html.contains("list-style-position: inside; padding-left: 0;"))
+    #expect(!html.contains("padding-left: 0; margin: 0"))
+}
+
 @Test func serviceScopeHasNoProgressiveIndent() {
     let model = QuotingServiceTerm.Model(
         title: "標題",

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -42,6 +42,42 @@ import Foundation
 }
 
 
+// 服務內容（自訂服務項目走 .introOnly → 落在 QuotingServiceTerm.term）改吃 markdown：
+// 1. `- ` 要變成真正的 <ul><li>（原本整段是純文字，圓點印不出來）
+// 2. 段落內的 \n 要換行 —— 原本 `Div(term)` 完全不處理 \n，多行內容在 PDF 會連成一行
+// 3. 使用者輸入的 HTML 必須被 escape：這欄會印進報價單，不該讓自由文字注入標記
+//    （酬金補充說明那條路刻意允許 raw HTML，服務內容不比照）
+@Test func serviceScopeTermRendersMarkdownBulletList() {
+    let term = "本服務包含：\n- 每月帳務處理\n- 稅務申報代辦"
+    let model = QuotingServiceTerm.Model(title: "ItemTitle", term: term, serviceItemTerms: nil)
+    let html = ServiceScope(index: 0, model: .init(title: "T", heading: "H", items: [model])).render()
+
+    // swift-markdown 的 HTMLFormatter 對 list item 一律包 <p>（不分 tight/loose），
+    // 故斷言 `<li><p>…</p>` 而非 `<li>…</li>` —— 寫死後者會誤判成沒渲染。
+    #expect(html.contains("<ul>"))
+    #expect(html.contains("<li><p>每月帳務處理</p>"))
+    #expect(html.contains("<li><p>稅務申報代辦</p>"))
+    #expect(html.contains("<p>本服務包含：</p>"))
+}
+
+@Test func serviceScopeTermKeepsSingleNewlineAsLineBreak() {
+    let model = QuotingServiceTerm.Model(title: "ItemTitle", term: "第一行\n第二行", serviceItemTerms: nil)
+    let html = ServiceScope(index: 0, model: .init(title: "T", heading: "H", items: [model])).render()
+
+    #expect(html.contains("<br />"))
+    #expect(html.contains("第一行"))
+    #expect(html.contains("第二行"))
+}
+
+@Test func serviceScopeTermEscapesUserHtml() {
+    let model = QuotingServiceTerm.Model(title: "ItemTitle", term: "<script>alert(1)</script> a & b", serviceItemTerms: nil)
+    let html = ServiceScope(index: 0, model: .init(title: "T", heading: "H", items: [model])).render()
+
+    #expect(!html.contains("<script>"))
+    #expect(html.contains("&lt;script&gt;"))
+    #expect(html.contains("a &amp; b"))
+}
+
 @Test func createServiceScopeHtml(){
     let title = "Quotation Service Scope"
     let content = "This is a description of the Service Scope."
@@ -53,8 +89,12 @@ import Foundation
     
     let serviceScope = ServiceScope(index: 0, model: .init(title: title, heading: content, items: quotingServiceTerms))
     
+    // 服務內容改走 markdown 渲染後，term 外多包一層 .rich-serviceContent（見 ServiceContentHTMLRenderer）。
+    // style block 以常數內插而非貼死字串：否則之後微調清單縮排，這條 snapshot 又會誤紅。
+    let expectedContent = ServiceContentHTMLRenderer.scopedStyleBlock
+        + "<div class=\"rich-serviceContent\"><p>ItemContent</p>\n</div>"
     #expect(serviceScope.render() == """
-<div style="break-inside: avoid-page;"><div style="font-size: 1.1em;">一、Quotation Service Scope</div><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column; padding-left: 2em;"><div style="display: flex; padding-left: 3em; text-indent: 2em;">ItemContent</div></div></div>
+<div style="break-inside: avoid-page;"><div style="font-size: 1.1em;">一、Quotation Service Scope</div><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column; padding-left: 2em;"><div style="display: flex; padding-left: 3em; text-indent: 2em;">\(expectedContent)</div></div></div>
 """)
 }
 

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -78,6 +78,24 @@ import Foundation
     #expect(html.contains("a &amp; b"))
 }
 
+// 服務範圍原本是三層遞進縮排（標題 text-indent:2em → 內文 2em+3em+2em → 編號項 3.8em），
+// 使用者要求內文與編號項全部對齊同一條左緣。這條鎖住「不再有遞進 padding」——
+// 沒有它，之後有人為了某個版面問題把 padding 加回來不會有任何訊號。
+@Test func serviceScopeHasNoProgressiveIndent() {
+    let model = QuotingServiceTerm.Model(
+        title: "標題",
+        term: "內文",
+        serviceItemTerms: [.init(content: "工作項目一"), .init(content: "工作項目二")]
+    )
+    let html = ServiceScope(index: 0, model: .init(title: "T", heading: "H", items: [model])).render()
+
+    #expect(!html.contains("padding-left: 2em"))
+    #expect(!html.contains("padding-left: 3em"))
+    #expect(!html.contains("padding-left: 3.8em"))
+    // 編號清單不吃預設縮排、標記排進文字流
+    #expect(html.contains("list-style-position: inside; padding-left: 0"))
+}
+
 @Test func createServiceScopeHtml(){
     let title = "Quotation Service Scope"
     let content = "This is a description of the Service Scope."
@@ -94,7 +112,7 @@ import Foundation
     let expectedContent = ServiceContentHTMLRenderer.scopedStyleBlock
         + "<div class=\"rich-serviceContent\"><p>ItemContent</p>\n</div>"
     #expect(serviceScope.render() == """
-<div style="break-inside: avoid-page;"><div style="font-size: 1.1em;">一、Quotation Service Scope</div><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column; padding-left: 2em;"><div style="display: flex; padding-left: 3em; text-indent: 2em;">\(expectedContent)</div></div></div>
+<div style="break-inside: avoid-page;"><div style="font-size: 1.1em;">一、Quotation Service Scope</div><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column;"><div style="display: flex;">\(expectedContent)</div></div></div>
 """)
 }
 

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -79,8 +79,8 @@ import Foundation
 }
 
 // 服務範圍原本是三層遞進縮排（標題 text-indent:2em → 內文 2em+3em+2em → 編號項 3.8em），
-// 使用者要求內文與編號項全部對齊同一條左緣。這條鎖住「不再有遞進 padding」——
-// 沒有它，之後有人為了某個版面問題把 padding 加回來不會有任何訊號。
+// 一層比一層右。要求是內文與編號項**共用同一層縮排**（仍縮在標題底下，不是貼齊容器左緣）。
+// 這條鎖住「兩者深度相同」——分開寫就會重演遞進縮排，而版面問題不會有測試訊號。
 @Test func serviceScopeHasNoProgressiveIndent() {
     let model = QuotingServiceTerm.Model(
         title: "標題",
@@ -89,10 +89,14 @@ import Foundation
     )
     let html = ServiceScope(index: 0, model: .init(title: "T", heading: "H", items: [model])).render()
 
+    // 舊的三個不同深度都不該再出現
     #expect(!html.contains("padding-left: 2em"))
     #expect(!html.contains("padding-left: 3em"))
     #expect(!html.contains("padding-left: 3.8em"))
-    // 編號清單不吃預設縮排、標記排進文字流
+    // 內文與編號項共用同一個深度：出現兩次（各一個外層容器）
+    let indentOccurrences = html.components(separatedBy: "padding-left: \(ServiceScope.bodyIndent)").count - 1
+    #expect(indentOccurrences == 2)
+    // 編號清單不吃預設縮排、標記排進文字流（否則編號會比內文右一截）
     #expect(html.contains("list-style-position: inside; padding-left: 0"))
 }
 
@@ -112,7 +116,7 @@ import Foundation
     let expectedContent = ServiceContentHTMLRenderer.scopedStyleBlock
         + "<div class=\"rich-serviceContent\"><p>ItemContent</p>\n</div>"
     #expect(serviceScope.render() == """
-<div style="break-inside: avoid-page;"><div style="font-size: 1.1em;">一、Quotation Service Scope</div><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column;"><div style="display: flex;">\(expectedContent)</div></div></div>
+<div style="break-inside: avoid-page;"><div style="font-size: 1.1em;">一、Quotation Service Scope</div><p style="text-indent: 2em;">This is a description of the Service Scope.</p></div><div style="display: flex; flex-direction: column;  break-inside: avoid-page; "><div style="display: flex; text-indent: 2em;">（一）ItemTitle</div><div style="display: flex; flex-direction: column; padding-left: \(ServiceScope.bodyIndent);"><div style="display: flex;">\(expectedContent)</div></div></div>
 """)
 }
 

--- a/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
+++ b/Tests/PDFGeneratorTests/PDFGeneratorTests.swift
@@ -84,6 +84,18 @@ import Foundation
 // `<ol>` 的上下 margin 不得歸零：它就是「內文與第一個編號項之間」那道間距。
 // 為了讓編號與內文同左緣只需要關掉 padding-left，一併寫 margin: 0 會讓整段比原本更擠
 // （行距本身是 Quotation.swift 根容器的 1.5em，與這裡無關）。
+// 清單標記不得與內容分行。`swift-markdown` 把 li 內容包成 `<p>`（block），
+// 而 `list-style-position: inside` 的標記是行內的 → 標記自己佔一行、文字掉到下一行。
+// 實際 PDF 出現過這個症狀；沒有這條就只能靠印出來才發現。
+@Test func serviceContentListMarkerStaysOnTheSameLineAsItsText() {
+    let html = ServiceContentHTMLRenderer.render(markdown: "- 內容內容內容")
+
+    // 渲染結果確實是 <li><p>…（這是症狀的來源）
+    #expect(html.contains("<li><p>內容內容內容</p>"))
+    // 故必須把 li 內第一段轉成 inline
+    #expect(html.contains(".rich-serviceContent li > p { display: inline; }"))
+}
+
 @Test func serviceScopeKeepsListBlockSpacing() {
     let model = QuotingServiceTerm.Model(
         title: "標題", term: "內文", serviceItemTerms: [.init(content: "工作項目")]


### PR DESCRIPTION
## 這支在做什麼

報價單 PDF 的「服務範圍」段落原本有兩個問題：

1. **自訂服務項目的服務內容進不了 PDF**：原本是 `Div(term)`，Plot 會 escape 但完全不處理 `\n`，多行內容在 PDF 會連成一行，項目符號清單也印不出來。
2. **縮排是三個不同深度**：外層 2em ＋ 自身 3em ＋ `text-indent: 2em`，而編號項另外 3.8em —— 一層比一層右。

## 改了什麼

- 服務內容改走 `ServiceContentHTMLRenderer`，以 CommonMark 渲染（項目符號清單 + 段落內換行），escape 由 renderer 負責。
- 縮排收斂成一層：內文與編號項共用 `bodyIndent`，都對齊到標題的第一個字。`5em` 是算出來的不是估的 —— 標題自己 `text-indent: 2em`，前綴「（一）」佔 3 個全形字（≈3em）。
- 編號清單改用 `list-style-position: outside` + `padding-left: 0.8em`，讓折行縮在項目內（hanging indent）。

## 最後一筆（62da6b9）的驗證方式

`inside` 會把標記排進文字流，於是折行回到標記左緣、跟「1.」對齊，長項目讀起來像下一個項目的開頭：

```
1. 每月薪資複核作業，包括:員工出、缺勤之薪資複核、薪資表、薪資條製
作、薪資扣繳稅款及二代健保繳費計算作業      ← 折行貼齊「1.」
2. 每月勞、健保及勞工退休金作業…
```

改 `outside` 後折行縮進項目內。`0.8em` 是實測值不是猜的：把同一份 HTML 結構（外層 `padding-left: 5em`、flex 容器、`line-height: 1.5em`）用 weasyprint 渲成 PDF 再轉圖比對，而且**用真正的標楷體**（`標楷體-繁 / BiauKaiTC`）—— 這個值是標記欄寬、跟數字字寬直接相關，用別的字體調出來的值搬到標楷體會偏（先用 PingFang 試出 0.9em，換標楷體後落在 0.8em）。候選值 0.8 / 1.0 / 1.2em 都渲出來看過，0.8em 是「1.」左緣正好對齊上方內文第一個字的那個。

`outside` 的附帶好處：位數變多時（「10.」）標記往左長、文字欄不動，所有項目的文字左緣一致；`inside` 做不到。

`margin` 刻意不歸零 —— 歸零會一併拿掉內文與第一個編號項之間的間距（該檔註解已記錄此事，先前踩過）。

## 下游

`OpportunityContext` 目前 `Package.swift` 暫指這支 branch 測試中。合併發版後那邊改回版本號。

🤖 Generated with [Claude Code](https://claude.com/claude-code)